### PR TITLE
[codex] upgrade community RCC to v18.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This stack is hands down the easiest way to give AI agents more capabilities. It
 
 ## Community Edition
 
-This build uses the **[joshyorko/rcc](https://github.com/joshyorko/rcc)** fork (v18.17.1) - a fully open-source version of RCC with several key benefits:
+This build uses the **[joshyorko/rcc](https://github.com/joshyorko/rcc)** fork (v18.17.3) - a fully open-source version of RCC with several key benefits:
 
 ### Why the Community RCC Fork?
 
@@ -225,7 +225,7 @@ This build uses the **[joshyorko/rcc](https://github.com/joshyorko/rcc)** fork (
 | **Infrastructure Dependencies** | Cloud services | None - fully decoupled |
 | **Telemetry** | Telemetry enabled | Minimal/disabled |
 | **Startup Speed** | Standard | Faster (fewer network calls) |
-| **Go Version** | Varies | 1.23 (latest security patches) |
+| **Go Version** | Varies | 1.25.7 (current upstream toolchain) |
 
 ### Performance Benefits
 
@@ -259,7 +259,7 @@ To clear caches: `action-server env clean-tools-caches`
 - **Node.js**: LTS 20.x (20.9.0 or later)
 - **npm**: 10.x or later (bundled with Node.js)
 - **Python**: 3.11+ (for the Action Server backend)
-- **RCC**: [joshyorko/rcc](https://github.com/joshyorko/rcc) v18.17.1+
+- **RCC**: [joshyorko/rcc](https://github.com/joshyorko/rcc) v18.17.3+
 
 ### Build the Frontend
 

--- a/action_server/README.md
+++ b/action_server/README.md
@@ -65,11 +65,11 @@ The `package.yaml` file is required for specifying the Python environment and de
 
 ### Community RCC Fork
 
-This Action Server uses the **joshyorko/rcc v18.17.1** community fork, which provides:
+This Action Server uses the **joshyorko/rcc v18.17.3** community fork, which provides:
 - **Faster startup** - no proprietary cloud service calls
 - **Official sources** - downloads micromamba directly from conda-forge instead of Robocorp CDN
 - **Decoupled infrastructure** - works fully offline after initial environment bootstrap
-- **Security updates** - built with Go 1.23
+- **Security hardening** - includes upstream archive extraction and TLS fixes, built with Go 1.25.7
 
 Environment caching means subsequent startups are near-instant once the holotree is built.
 

--- a/action_server/build.py
+++ b/action_server/build.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 # Note: referenced here and in sema4ai.action_server._download_rcc
 # Using joshyorko/rcc open-source version
-RCC_VERSION = "18.17.1"
+RCC_VERSION = "18.17.3"
 
 
 CURDIR = Path(__file__).parent.absolute()

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.2.4 - 2026-03-15
+
+### Fixes
+- Updated the community RCC integration from `joshyorko/rcc` `v18.17.1` to `v18.17.3` across download/build scripts, shared test fixtures, and docs. This picks up the upstream Go 1.25.7 toolchain refresh plus the `v18.17.3` security fixes for archive extraction and TLS handling.
+
 ## 1.2.3 - 2026-02-21
 
 ### Fixes

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "1.2.3"
+version = "1.2.4"
 description = """Sema4AI Action Server"""
 authors = [
 	"Sema4.ai, Inc. <dev@sema4.ai>",

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []

--- a/action_server/src/sema4ai/action_server/_download_rcc.py
+++ b/action_server/src/sema4ai/action_server/_download_rcc.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 # Note: also referenced in action_server/build.py
 # Using joshyorko/rcc open-source version
-RCC_VERSION = "18.17.1"
+RCC_VERSION = "18.17.3"
 
 
 def get_default_rcc_location() -> Path:

--- a/common/tests/sema4ai_common_tests/test_tools.py
+++ b/common/tests/sema4ai_common_tests/test_tools.py
@@ -81,20 +81,20 @@ def test_rcc_tool(tmpdir):
     target = tmpdir / f"rcc{suffix}"
 
     # Using joshyorko/rcc version (see: https://github.com/joshyorko/rcc/releases)
-    tool = RccTool(target, "v18.17.1")
+    tool = RccTool(target, "v18.17.3")
     assert not tool.verify()
     tool.download()
     assert tool.verify()
 
     target = tmpdir / "rcc-in_mac_arm"
-    tool = RccTool(target, "v18.17.1")
+    tool = RccTool(target, "v18.17.3")
     tool.force_sys_platform = "darwin"
     tool.force_machine = "arm64"
     tool.make_run_check = False
     tool.download()
     assert tool.verify()
 
-    executable = RccTool.get_default_executable(version="v18.17.1", download=True)
+    executable = RccTool.get_default_executable(version="v18.17.3", download=True)
     assert executable.exists()
     assert executable.is_file()
 

--- a/devutils/bin/develop.bat
+++ b/devutils/bin/develop.bat
@@ -12,7 +12,7 @@ SET activatePath=%scriptPath%\activate.bat
 
 echo 
 :: Get RCC binary using joshyorko/rcc GitHub releases
-SET rccUrl=https://github.com/joshyorko/rcc/releases/download/v18.17.1/rcc-windows64.exe
+SET rccUrl=https://github.com/joshyorko/rcc/releases/download/v18.17.3/rcc-windows64.exe
 IF NOT EXIST "%rccPath%" (
     curl -o %rccPath% %rccUrl% --fail || goto env_error
 )

--- a/devutils/bin/develop.sh
+++ b/devutils/bin/develop.sh
@@ -12,7 +12,7 @@ ACTIVATE_PATH="$SCRIPT_PATH/activate.sh"
 echo
 
 # Get RCC binary based on platform using joshyorko/rcc GitHub releases
-RCC_VERSION="v18.17.1"
+RCC_VERSION="v18.17.3"
 if [[ "$(uname)" == "Darwin" ]]; then
     if [[ "$(uname -m)" == "arm64" ]]; then
         RCC_URL="https://github.com/joshyorko/rcc/releases/download/$RCC_VERSION/rcc-macosarm64"

--- a/devutils/src/devutils/fixtures.py
+++ b/devutils/src/devutils/fixtures.py
@@ -89,7 +89,7 @@ def sema4ai_home(tmpdir_factory) -> str:
 
 
 # Using joshyorko/rcc open-source version
-RCC_VERSION = "v18.17.1"
+RCC_VERSION = "v18.17.3"
 
 
 def _download_rcc(location: str, force: bool = False) -> None:


### PR DESCRIPTION
## Summary
This updates the community RCC integration used by Action Server from `joshyorko/rcc` `v18.17.1` to `v18.17.3` and bumps the Action Server package version to `1.2.4`.

The immediate user-facing effect is that new Action Server downloads and local developer bootstrap flows now pull the latest community RCC build. That picks up the upstream `v18.17.2` Go toolchain refresh to `1.25.7` and the `v18.17.3` security fixes called out in the upstream RCC repository for archive extraction and TLS handling.

## Root Cause
The community branch had already switched to the open-source `joshyorko/rcc` fork, but the pinned version remained on `v18.17.1` across Action Server download paths, developer helper scripts, shared test fixtures, and user-facing documentation. That left the packaged and documented RCC version behind the latest upstream security and toolchain updates.

## Fix
The RCC pins were updated in the Action Server build/download code, developer bootstrap scripts, and shared RCC test fixtures. The top-level README and Action Server README were refreshed so the documented RCC version and Go toolchain details match the upstream release being consumed. The Action Server changelog was updated with a dated `1.2.4` entry, and the package metadata was bumped from `1.2.3` to `1.2.4` so the release history stays coherent with the shipped RCC change.

## Validation
I validated the resulting package metadata and RCC target path directly:

- `cd action_server && poetry run python -c "import sema4ai.action_server as m; from sema4ai.action_server._download_rcc import get_default_rcc_location; print(m.__version__); print(get_default_rcc_location().name)"`

I also ran targeted tests that exercise the updated RCC version path:

- `cd action_server && poetry run pytest tests/action_server_tests/test_cli.py -k 'test_version or test_download_rcc' -vv`
- `cd common && POETRY_VIRTUALENVS_CREATE=true poetry run pytest tests/sema4ai_common_tests/test_tools.py -k test_rcc_tool -vv`

Both targeted test runs passed.
