### PR TITLE
fix(work-items): retain release artifacts

### DIFF
--- a/.devcontainer/tests/test_contract.py
+++ b/.devcontainer/tests/test_contract.py
@@ -197,7 +197,9 @@ class DevContainerContractTest(unittest.TestCase):
         ):
             self.assertIn(action, workflow)
 
-        self.assertIn("verify-work-items work-items/dist", workflow)
+        self.assertIn(
+            'verify-work-items "$GITHUB_WORKSPACE/work-items/dist"', workflow
+        )
         self.assertIn("name: actions-work-items-dist", workflow)
         self.assertIn("needs: verify", workflow)
         self.assertIn("environment: pypi", workflow)

--- a/.github/workflows/work_items_release.yml
+++ b/.github/workflows/work_items_release.yml
@@ -46,7 +46,7 @@ jobs:
         run: poetry -C work-items sync --no-interaction
 
       - name: Verify release artifacts
-        run: .devcontainer/bin/verify-work-items work-items/dist
+        run: .devcontainer/bin/verify-work-items "$GITHUB_WORKSPACE/work-items/dist"
 
       - name: Upload verified Work Items artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/docs/skills/work-items.md
+++ b/docs/skills/work-items.md
@@ -33,7 +33,7 @@ docker run --rm --user vscode -v "$PWD:/workspaces/actions" -w /workspaces/actio
 
 ## CI Publication and Recovery
 
-The Work Items release workflow verifies relevant pull requests, relevant pushes to `community`, and `actions-work-items-*` tags. Verification uses Python 3.12 and Poetry 2.1.1, synchronizes the committed Work Items lock, runs `verify-work-items work-items/dist`, and uploads the resulting wheel and sdist as `actions-work-items-dist`.
+The Work Items release workflow verifies relevant pull requests, relevant pushes to `community`, and `actions-work-items-*` tags. Verification uses Python 3.12 and Poetry 2.1.1, synchronizes the committed Work Items lock, passes `$GITHUB_WORKSPACE/work-items/dist` to `verify-work-items` as an absolute retained-artifact path, and uploads the resulting wheel and sdist as `actions-work-items-dist`. Caller artifact paths must be absolute because Poetry build commands execute from the package directory.
 
 Do not enable setup-python's Poetry cache before Poetry is installed: the cache initialization resolves the `poetry` executable during setup and fails a fresh GitHub runner. The release workflow deliberately relies on the committed lock and installs Poetry after Python setup without that cache mode.
 


### PR DESCRIPTION
Fixes the merged Work Items workflow after the community run proved a relative artifact destination is interpreted from the package build directory. Uses the absolute GitHub workspace path, contract-tests it, and documents the invariant. All 7 release contracts pass; no tag or PyPI publication occurred.