### PR TITLE
feat: make Action Run control replica-safe

### DIFF
--- a/action_server/src/actions/server/_runs_state_cache.py
+++ b/action_server/src/actions/server/_runs_state_cache.py
@@ -7,6 +7,7 @@ way to synchronize state across multiple processes.
 import logging
 import threading
 import typing
+import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Literal, Optional
@@ -27,14 +28,28 @@ class RunChangeEvent:
 
 
 class RunRuntimeInfo:
-    def __init__(self, run_id: str):
+    def __init__(self, run_id: str, ownership=None, lease=None):
         from actions.server._robo_utils.callback import Callback
 
         self._run_id = run_id
         self._canceled = False
         self.on_cancel = Callback()
+        self._ownership = ownership
+        self._lease = lease
+        self._monitor_stop = threading.Event()
+        if ownership is not None and lease is not None:
+            threading.Thread(target=self._monitor_control, daemon=True).start()
+
+    def _monitor_control(self):
+        while not self._monitor_stop.wait(0.25):
+            self._ownership.renew(self._run_id, self._lease.epoch)
+            if self._ownership.control_requested(self._run_id, self._lease.epoch):
+                self.cancel()
+                return
 
     def cancel(self):
+        if self._canceled:
+            return
         self._canceled = True
 
         if not len(self.on_cancel):
@@ -43,6 +58,9 @@ class RunRuntimeInfo:
             )
 
         self.on_cancel()  # Notify all listeners that the run was canceled.
+
+    def close(self):
+        self._monitor_stop.set()
 
     def is_canceled(self) -> bool:
         return self._canceled
@@ -71,6 +89,16 @@ class RunsState:
 
         self._db = db
         self._run_id_to_runtime_info: dict[str, RunRuntimeInfo] = {}
+        from .run_ownership import RunOwnershipStore
+
+        self.ownership = RunOwnershipStore(
+            db.db_path, owner_id=f"runtime-{uuid.uuid4()}"
+        )
+        from ._models import Run
+
+        with db.connect():
+            for run in db.all(Run):
+                self.ownership.create_run(run.id)
 
     def get_current_run_state(self, offset: int = 0, limit: int = 200) -> list["Run"]:
         from ._database import Database
@@ -135,6 +163,7 @@ class RunsState:
         from ._models import Run
 
         run_copy = Run(**asdict(run))
+        self.ownership.create_run(run.id)
         with self.semaphore:
             for listener in self._run_listeners.keys():
                 listener(RunChangeEvent("added", run_copy))
@@ -143,7 +172,9 @@ class RunsState:
         """
         Creates the runtime info for a run and returns it.
         """
-        runtime_info = RunRuntimeInfo(run_id)
+        self.ownership.create_run(run_id)
+        lease = self.ownership.claim(run_id)
+        runtime_info = RunRuntimeInfo(run_id, self.ownership, lease)
         assert run_id not in self._run_id_to_runtime_info
         self._run_id_to_runtime_info[run_id] = runtime_info
         return runtime_info
@@ -155,13 +186,25 @@ class RunsState:
         from ._models import Run
 
         run_copy = Run(**asdict(run))
+        runtime_info = self._run_id_to_runtime_info.get(run_copy.id)
+        if runtime_info is not None and "status" in changes:
+            self.ownership.set_status(
+                run_copy.id,
+                runtime_info._lease.epoch,
+                "running" if changes["status"] == RunStatus.RUNNING else "finished",
+            )
         with self.semaphore:
             for listener in self._run_listeners.keys():
                 listener(RunChangeEvent("changed", run_copy, changes))
 
             if run_copy.status not in (RunStatus.RUNNING, RunStatus.NOT_RUN):
                 # Finished run, remove from runtime info.
-                self._run_id_to_runtime_info.pop(run_copy.id, None)
+                runtime_info = self._run_id_to_runtime_info.pop(run_copy.id, None)
+                if runtime_info is not None:
+                    runtime_info.close()
+                    self.ownership.reconcile(
+                        run_copy.id, runtime_info._lease.epoch, "running"
+                    )
 
     def cancel_run(self, run_id: str) -> bool:
         """
@@ -180,8 +223,9 @@ class RunsState:
                 log.info(f"Cancelling run {run_id}.")
                 runtime_info.cancel()
                 return True
-            log.info(f"Unable to cancel run {run_id} (no runtime info found).")
-            return False
+            requested = self.ownership.request_cancel(run_id)
+            log.info("Durable cancellation for %s: %s", run_id, requested)
+            return requested
 
 
 _runs_state: Optional[RunsState] = None

--- a/action_server/src/actions/server/run_ownership.py
+++ b/action_server/src/actions/server/run_ownership.py
@@ -82,28 +82,32 @@ class RunOwnershipStore:
         now = time.time()
         expires_at = now + self.lease_seconds
         with self._connect() as db:
-            db.execute("BEGIN IMMEDIATE")
-            row = db.execute(
-                "SELECT owner_id, owner_epoch, lease_expires_at FROM run_ownership "
-                "WHERE run_id = ?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
+            try:
+                db.execute("BEGIN IMMEDIATE")
+                row = db.execute(
+                    "SELECT owner_id, owner_epoch, lease_expires_at FROM run_ownership "
+                    "WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise KeyError(run_id)
+                current_owner, current_epoch, current_expiry = row
+                if current_owner not in (None, self.owner_id) and (
+                    current_expiry is not None and current_expiry > now
+                ):
+                    raise RuntimeError(
+                        f"run {run_id} is owned by another live Runtime"
+                    )
+                epoch = current_epoch + 1
+                db.execute(
+                    "UPDATE run_ownership SET owner_id=?, owner_epoch=?, lease_expires_at=? "
+                    "WHERE run_id=?",
+                    (self.owner_id, epoch, expires_at, run_id),
+                )
+                db.commit()
+            except Exception:
                 db.rollback()
-                raise KeyError(run_id)
-            current_owner, current_epoch, current_expiry = row
-            if current_owner not in (None, self.owner_id) and (
-                current_expiry is not None and current_expiry > now
-            ):
-                db.rollback()
-                raise RuntimeError(f"run {run_id} is owned by another live Runtime")
-            epoch = current_epoch + 1
-            db.execute(
-                "UPDATE run_ownership SET owner_id=?, owner_epoch=?, lease_expires_at=? "
-                "WHERE run_id=?",
-                (self.owner_id, epoch, expires_at, run_id),
-            )
-            db.commit()
+                raise
         return RunLease(run_id, self.owner_id, epoch, expires_at)
 
     def renew(self, run_id: str, epoch: int) -> bool:

--- a/action_server/src/actions/server/run_ownership.py
+++ b/action_server/src/actions/server/run_ownership.py
@@ -1,0 +1,163 @@
+"""Durable ownership and control coordination for Action Runs.
+
+The execution handle remains process-local.  This store contains only the
+server-issued owner lease and durable control intent, so another Runtime can
+observe or control a run without addressing the owning process directly.
+"""
+
+from dataclasses import dataclass
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RunLease:
+    run_id: str
+    owner_id: str
+    epoch: int
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class RunOwnership:
+    run_id: str
+    owner_id: Optional[str]
+    epoch: int
+    expires_at: Optional[float]
+    control: Optional[str]
+    status: str
+
+
+class RunOwnershipStore:
+    """SQLite-backed lease/control store shared by Runtime processes."""
+
+    def __init__(
+        self, db_path: str | Path, *, owner_id: str, lease_seconds: float = 30.0
+    ) -> None:
+        if not owner_id:
+            raise ValueError("owner_id is required")
+        self.db_path = str(db_path)
+        self.owner_id = owner_id
+        self.lease_seconds = lease_seconds
+        with self._connect() as db:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_ownership (
+                    run_id TEXT PRIMARY KEY,
+                    owner_id TEXT,
+                    owner_epoch INTEGER NOT NULL DEFAULT 0,
+                    lease_expires_at REAL,
+                    control TEXT,
+                    status TEXT NOT NULL DEFAULT 'not_run'
+                )
+                """
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.db_path, timeout=30, isolation_level=None)
+        db.execute("PRAGMA busy_timeout = 30000")
+        return db
+
+    def create_run(self, run_id: str) -> None:
+        with self._connect() as db:
+            db.execute(
+                "INSERT INTO run_ownership(run_id) VALUES (?) ON CONFLICT(run_id) DO NOTHING",
+                (run_id,),
+            )
+
+    def get(self, run_id: str) -> RunOwnership:
+        with self._connect() as db:
+            row = db.execute(
+                "SELECT run_id, owner_id, owner_epoch, lease_expires_at, control, status "
+                "FROM run_ownership WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            raise KeyError(run_id)
+        return RunOwnership(*row)
+
+    def claim(self, run_id: str) -> RunLease:
+        now = time.time()
+        expires_at = now + self.lease_seconds
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            row = db.execute(
+                "SELECT owner_id, owner_epoch, lease_expires_at FROM run_ownership "
+                "WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                db.rollback()
+                raise KeyError(run_id)
+            current_owner, current_epoch, current_expiry = row
+            if current_owner not in (None, self.owner_id) and (
+                current_expiry is not None and current_expiry > now
+            ):
+                db.rollback()
+                raise RuntimeError(f"run {run_id} is owned by another live Runtime")
+            epoch = current_epoch + 1
+            db.execute(
+                "UPDATE run_ownership SET owner_id=?, owner_epoch=?, lease_expires_at=? "
+                "WHERE run_id=?",
+                (self.owner_id, epoch, expires_at, run_id),
+            )
+            db.commit()
+        return RunLease(run_id, self.owner_id, epoch, expires_at)
+
+    def renew(self, run_id: str, epoch: int) -> bool:
+        with self._connect() as db:
+            result = db.execute(
+                "UPDATE run_ownership SET lease_expires_at=? WHERE run_id=? "
+                "AND owner_id=? AND owner_epoch=?",
+                (time.time() + self.lease_seconds, run_id, self.owner_id, epoch),
+            )
+        return result.rowcount == 1
+
+    def request_cancel(self, run_id: str) -> bool:
+        with self._connect() as db:
+            result = db.execute(
+                "UPDATE run_ownership SET control='cancel' WHERE run_id=? "
+                "AND status IN ('not_run', 'running')",
+                (run_id,),
+            )
+        return result.rowcount == 1
+
+    def set_status(self, run_id: str, epoch: int, status: str) -> bool:
+        with self._connect() as db:
+            result = db.execute(
+                "UPDATE run_ownership SET status=? WHERE run_id=? AND owner_id=? "
+                "AND owner_epoch=?",
+                (status, run_id, self.owner_id, epoch),
+            )
+        return result.rowcount == 1
+
+    def control_requested(self, run_id: str, epoch: int) -> Optional[str]:
+        with self._connect() as db:
+            row = db.execute(
+                "SELECT control FROM run_ownership WHERE run_id=? AND owner_id=? "
+                "AND owner_epoch=? AND lease_expires_at > ?",
+                (run_id, self.owner_id, epoch, time.time()),
+            ).fetchone()
+        return row[0] if row else None
+
+    def reconcile(self, run_id: str, epoch: int, status: str) -> str:
+        if status not in {"not_run", "running"}:
+            raise ValueError("only active run states can be reconciled")
+        with self._connect() as db:
+            result = db.execute(
+                "UPDATE run_ownership SET status='reconciled', control=NULL "
+                "WHERE run_id=? AND owner_id=? AND owner_epoch=?",
+                (run_id, self.owner_id, epoch),
+            )
+        return "reconciled" if result.rowcount == 1 else "stale"
+
+    def release(self, run_id: str, epoch: int) -> bool:
+        with self._connect() as db:
+            result = db.execute(
+                "UPDATE run_ownership SET owner_id=NULL, lease_expires_at=NULL "
+                "WHERE run_id=? AND owner_id=? AND owner_epoch=?",
+                (run_id, self.owner_id, epoch),
+            )
+        return result.rowcount == 1

--- a/action_server/tests/action_server_tests/test_run_ownership.py
+++ b/action_server/tests/action_server_tests/test_run_ownership.py
@@ -1,0 +1,62 @@
+"""Acceptance contracts for durable Action Run ownership."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_remote_runtime_can_query_and_request_cancel(tmp_path: Path) -> None:
+    from actions.server.run_ownership import RunOwnershipStore
+
+    db_path = tmp_path / "runs.db"
+    owner = RunOwnershipStore(db_path, owner_id="runtime-a")
+    observer = RunOwnershipStore(db_path, owner_id="runtime-b")
+
+    owner.create_run("run-1")
+    lease = owner.claim("run-1")
+
+    assert observer.get("run-1").owner_id == "runtime-a"
+    assert observer.request_cancel("run-1") is True
+    assert owner.control_requested("run-1", lease.epoch) == "cancel"
+
+
+def test_expired_owner_can_be_reconciled_without_stale_fence(tmp_path: Path) -> None:
+    from actions.server.run_ownership import RunOwnershipStore
+
+    db_path = tmp_path / "runs.db"
+    first = RunOwnershipStore(db_path, owner_id="runtime-a", lease_seconds=0)
+    second = RunOwnershipStore(db_path, owner_id="runtime-b", lease_seconds=30)
+
+    first.create_run("run-1")
+    first_lease = first.claim("run-1")
+    second_lease = second.claim("run-1")
+
+    assert second_lease.epoch > first_lease.epoch
+    assert first.release("run-1", first_lease.epoch) is False
+    assert second.reconcile("run-1", second_lease.epoch, "running") == "reconciled"
+
+
+def test_two_independent_processes_observe_same_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "runs.db"
+    script = """
+from actions.server.run_ownership import RunOwnershipStore
+import sys
+store = RunOwnershipStore(sys.argv[1], owner_id=sys.argv[2])
+if sys.argv[3] == 'create':
+    store.create_run('run-1')
+    store.claim('run-1')
+else:
+    print(store.get('run-1').owner_id)
+"""
+    subprocess.run(
+        [sys.executable, "-c", script, str(db_path), "runtime-a", "create"],
+        check=True,
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(db_path), "runtime-b", "read"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "runtime-a"

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -124,6 +124,16 @@ A Dev Container counts as release evidence only after its repository-owned confi
 
 The Action Server Dev Container uses uv only to install and cache Poetry; Poetry and committed `poetry.lock` files remain the dependency-resolution and release authorities. The image declares the uv, Poetry, and npm cache paths and creates them as `vscode` before the runtime user switch, so newly created named volumes are writable. Bootstrap uses `poetry sync --no-interaction`. Run host Docker commands only from the repository root because their bind mount uses host `$PWD`; that requirement is separate from the in-container scripts, which resolve their own repository path and are cwd-independent.
 
+Action Run records are durable SQLite state, but execution callbacks and process
+handles are Runtime-local. The `run_ownership` table is the coordination seam:
+each Runtime uses a generated owner ID and fenced epoch lease, while remote
+control writes durable intent for the owner to observe. Expired owners may be
+reclaimed with a higher epoch; stale owners cannot release or update a newer
+lease. This preserves single-node SQLite/local-process behavior and does not
+use client IDs, PIDs, or MCP transport sessions as ownership identity. The
+backend ownership tests include two independent Python processes; full Action
+Server integration still requires the repository RCC bootstrap.
+
 ```bash
 docker build --pull=false -f .devcontainer/Dockerfile -t actions-devcontainer:test .
 docker run --rm --user vscode -v "$PWD:/workspaces/actions" -w /workspaces/actions actions-devcontainer:test .devcontainer/bin/smoke


### PR DESCRIPTION
Closes #83

## Factory lane
- Runtime-backend-only replica-safe Action Run ownership/control
- sole writer owns Action Run lifecycle/coordination implementation and directly required backend tests/docs
- excludes frontend paths and Runtime release workflows

## State
Implementation and RED acceptance are active in the isolated issue worktree. This draft is a visible factory checkpoint; it is not yet an implementation receipt.
