### PR TITLE
feat(frontend): unify Runtime data access

### DIFF
--- a/action_server/frontend/__tests__/api-client.test.ts
+++ b/action_server/frontend/__tests__/api-client.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectRunArtifacts } from "../src/shared/api-client";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("legacy artifact API client", () => {
+  it("serializes readonly array query values as repeated parameters", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const setLoaded = vi.fn();
+
+    await collectRunArtifacts("run-1", setLoaded, {
+      artifact_names: ["output.robolog", "console.robolog"],
+      format: "text",
+    });
+
+    const requestUrl = new URL(
+      String(fetchMock.mock.calls[0][0]),
+      "http://localhost",
+    );
+    expect(requestUrl.searchParams.getAll("artifact_names")).toEqual([
+      "output.robolog",
+      "console.robolog",
+    ]);
+    expect(requestUrl.searchParams.get("format")).toBe("text");
+  });
+});

--- a/action_server/frontend/__tests__/runtime-api.test.ts
+++ b/action_server/frontend/__tests__/runtime-api.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cancelRuntimeRun,
+  getRuntimeRun,
+  listRuntimeActions,
+  listRuntimeRuns,
+  runRuntimeAction,
+  RuntimeApiError,
+} from "../src/shared/runtime-api";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Runtime API", () => {
+  it("uses typed list and detail calls with the expected endpoints", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "run-1" }), { status: 200 }),
+      );
+    await listRuntimeActions();
+    await getRuntimeRun("run-1");
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      "/api/actionPackages",
+      "/api/runs/run-1",
+    ]);
+  });
+
+  it("supports typed list and mutation payloads", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ run_id: "run-1" }), { status: 200 }),
+      );
+    await listRuntimeRuns("robot");
+    await runRuntimeAction({
+      actionPackageName: "pkg",
+      actionName: "task",
+      args: { value: 1 },
+    });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("run_type=robot");
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: "POST" });
+  });
+
+  it("turns HTTP errors into typed errors and forwards cancellation", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "nope" }), { status: 409 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }));
+    await expect(listRuntimeActions()).rejects.toBeInstanceOf(RuntimeApiError);
+    await cancelRuntimeRun("run-1", controller.signal);
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      method: "POST",
+      signal: controller.signal,
+    });
+  });
+});

--- a/action_server/frontend/__tests__/runtime-api.test.ts
+++ b/action_server/frontend/__tests__/runtime-api.test.ts
@@ -50,9 +50,13 @@ describe("Runtime API", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ detail: "nope" }), { status: 409 }),
       )
-      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }));
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify("cancelled"), { status: 200 }),
+      );
     await expect(listRuntimeActions()).rejects.toBeInstanceOf(RuntimeApiError);
-    await cancelRuntimeRun("run-1", controller.signal);
+    await expect(cancelRuntimeRun("run-1", controller.signal)).resolves.toBe(
+      "cancelled",
+    );
     expect(fetchMock.mock.calls[1][1]).toMatchObject({
       method: "POST",
       signal: controller.signal,

--- a/action_server/frontend/__tests__/runtime-events.test.ts
+++ b/action_server/frontend/__tests__/runtime-events.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  applyRuntimeEvent,
+  createRuntimeEventAdapter,
+} from "../src/shared/runtime-events";
+import { runtimeQueryKeys } from "../src/shared/runtime-query-keys";
+
+describe("Runtime event freshness adapter", () => {
+  it("invalidates canonical queries without maintaining a second store", async () => {
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const adapter = createRuntimeEventAdapter(client);
+    await adapter({
+      type: "run_changed",
+      sequence: 2,
+      run_id: "run-1",
+      changes: {},
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: runtimeQueryKeys.runs(),
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: runtimeQueryKeys.run("run-1"),
+    });
+  });
+
+  it("ignores duplicate and older events so stale events cannot regress cache data", async () => {
+    const client = new QueryClient();
+    client.setQueryData(runtimeQueryKeys.run("run-1"), {
+      id: "run-1",
+      status: "new",
+    });
+    const adapter = createRuntimeEventAdapter(client);
+    const invalidate = vi
+      .spyOn(client, "invalidateQueries")
+      .mockResolvedValue();
+    await adapter({
+      type: "run_changed",
+      sequence: 3,
+      run_id: "run-1",
+      changes: { status: "latest" },
+    });
+    await adapter({
+      type: "run_changed",
+      sequence: 3,
+      run_id: "run-1",
+      changes: { status: "stale" },
+    });
+    await adapter({
+      type: "run_changed",
+      sequence: 2,
+      run_id: "run-1",
+      changes: { status: "staler" },
+    });
+    expect(invalidate).toHaveBeenCalledTimes(2);
+    expect(client.getQueryData(runtimeQueryKeys.run("run-1"))).toEqual({
+      id: "run-1",
+      status: "new",
+    });
+  });
+
+  it("refreshes all Runtime keys after reconnect and accepts direct events", async () => {
+    const client = new QueryClient();
+    const invalidate = vi
+      .spyOn(client, "invalidateQueries")
+      .mockResolvedValue();
+    await applyRuntimeEvent(client, { type: "connect", sequence: 1 });
+    await applyRuntimeEvent(client, { type: "mtime_changed", sequence: 2 });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: runtimeQueryKeys.root,
+    });
+  });
+});

--- a/action_server/frontend/__tests__/runtime-events.test.ts
+++ b/action_server/frontend/__tests__/runtime-events.test.ts
@@ -13,7 +13,6 @@ describe("Runtime event freshness adapter", () => {
     const adapter = createRuntimeEventAdapter(client);
     await adapter({
       type: "run_changed",
-      sequence: 2,
       run_id: "run-1",
       changes: {},
     });
@@ -25,7 +24,7 @@ describe("Runtime event freshness adapter", () => {
     });
   });
 
-  it("ignores duplicate and older events so stale events cannot regress cache data", async () => {
+  it("treats duplicate and out-of-order events as freshness signals only", async () => {
     const client = new QueryClient();
     client.setQueryData(runtimeQueryKeys.run("run-1"), {
       id: "run-1",
@@ -37,23 +36,20 @@ describe("Runtime event freshness adapter", () => {
       .mockResolvedValue();
     await adapter({
       type: "run_changed",
-      sequence: 3,
       run_id: "run-1",
       changes: { status: "latest" },
     });
     await adapter({
       type: "run_changed",
-      sequence: 3,
       run_id: "run-1",
       changes: { status: "stale" },
     });
     await adapter({
       type: "run_changed",
-      sequence: 2,
       run_id: "run-1",
       changes: { status: "staler" },
     });
-    expect(invalidate).toHaveBeenCalledTimes(2);
+    expect(invalidate).toHaveBeenCalledTimes(6);
     expect(client.getQueryData(runtimeQueryKeys.run("run-1"))).toEqual({
       id: "run-1",
       status: "new",
@@ -65,8 +61,8 @@ describe("Runtime event freshness adapter", () => {
     const invalidate = vi
       .spyOn(client, "invalidateQueries")
       .mockResolvedValue();
-    await applyRuntimeEvent(client, { type: "connect", sequence: 1 });
-    await applyRuntimeEvent(client, { type: "mtime_changed", sequence: 2 });
+    await applyRuntimeEvent(client, { type: "connect" });
+    await applyRuntimeEvent(client, { type: "mtime_changed" });
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: runtimeQueryKeys.root,
     });

--- a/action_server/frontend/__tests__/runtime-providers.test.tsx
+++ b/action_server/frontend/__tests__/runtime-providers.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+vi.mock("../src/shared/runtime-events", () => ({
+  subscribeRuntimeEvents: vi.fn(() => vi.fn()),
+}));
+vi.mock("../src/shared/hooks/useLocalStorage", () => ({
+  useLocalStorage: () => [{ theme: "dark" }, vi.fn()],
+}));
+
+import { RuntimeProviders } from "../src/app/RuntimeProviders";
+
+afterEach(() => cleanup());
+
+describe("RuntimeProviders", () => {
+  it("owns an isolated QueryClient per mounted provider and clears it on teardown", () => {
+    const clients: ReturnType<typeof useQueryClient>[] = [];
+    const Probe = () => {
+      const client = useQueryClient();
+      useEffect(() => {
+        clients.push(client);
+        client.setQueryData(["probe"], "owned");
+      }, [client]);
+      return null;
+    };
+
+    const first = render(
+      <RuntimeProviders>
+        <Probe />
+      </RuntimeProviders>,
+    );
+    const second = render(
+      <RuntimeProviders>
+        <Probe />
+      </RuntimeProviders>,
+    );
+
+    expect(clients[0]).not.toBe(clients[1]);
+    expect(clients[0].getQueryData(["probe"])).toBe("owned");
+    expect(clients[1].getQueryData(["probe"])).toBe("owned");
+
+    const firstClient = clients[0];
+    first.unmount();
+    expect(firstClient.getQueryCache().getAll()).toHaveLength(0);
+    expect(clients[1].getQueryData(["probe"])).toBe("owned");
+    expect(clients[1].getQueryCache().getAll().length).toBeGreaterThan(0);
+    second.unmount();
+  });
+});

--- a/action_server/frontend/__tests__/runtime-query-keys.test.ts
+++ b/action_server/frontend/__tests__/runtime-query-keys.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { runtimeQueryKeys } from "../src/shared/runtime-query-keys";
+
+describe("Runtime query keys", () => {
+  it("provides stable hierarchical keys for shared Runtime state", () => {
+    expect(runtimeQueryKeys.actions()).toEqual(["runtime", "actions"]);
+    expect(runtimeQueryKeys.runs()).toEqual(["runtime", "runs", "all"]);
+    expect(runtimeQueryKeys.runs("robot")).toEqual([
+      "runtime",
+      "runs",
+      "robot",
+    ]);
+    expect(runtimeQueryKeys.run("run-1")).toEqual(["runtime", "run", "run-1"]);
+    expect(runtimeQueryKeys.config()).toEqual(["runtime", "config"]);
+  });
+});

--- a/action_server/frontend/__tests__/websocketConn.test.ts
+++ b/action_server/frontend/__tests__/websocketConn.test.ts
@@ -40,14 +40,63 @@ describe("WebsocketConn", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
-  it("handles duplicate close and error notifications without duplicate reconnects", async () => {
+  it("schedules only one reconnect when the same socket closes twice", async () => {
+    const socket = new WebsocketConn("ws://example.test");
+    const connecting = socket.connect();
+    FakeWebSocket.instances[0].onopen?.();
+    await connecting;
+
+    FakeWebSocket.instances[0].onclose?.();
+    FakeWebSocket.instances[0].onclose?.();
+
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("handles close and error notifications without duplicate reconnects", async () => {
     const socket = new WebsocketConn("ws://example.test");
     const connecting = socket.connect();
     FakeWebSocket.instances[0].onerror?.();
     await expect(connecting).rejects.toBeUndefined();
     FakeWebSocket.instances[0].onclose?.();
+    expect(vi.getTimerCount()).toBe(1);
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("ignores a stale close after a newer socket is active", async () => {
+    const socket = new WebsocketConn("ws://example.test");
+    const connecting = socket.connect();
+    FakeWebSocket.instances[0].onopen?.();
+    await connecting;
+    const oldSocket = FakeWebSocket.instances[0];
+    oldSocket.onclose?.();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const reconnecting = socket.connect();
+    FakeWebSocket.instances[1].onopen?.();
+    await reconnecting;
+    oldSocket.onclose?.();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("does not reconnect after repeated disconnect disposes a scheduled retry", async () => {
+    const socket = new WebsocketConn("ws://example.test");
+    const connecting = socket.connect();
+    FakeWebSocket.instances[0].onopen?.();
+    await connecting;
+    FakeWebSocket.instances[0].onclose?.();
+
+    socket.disconnect();
+    socket.disconnect();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 });

--- a/action_server/frontend/__tests__/websocketConn.test.ts
+++ b/action_server/frontend/__tests__/websocketConn.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebsocketConn } from "../src/shared/utils/websocketConn";
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((message: MessageEvent) => void) | null = null;
+  close = vi.fn(() => this.onclose?.());
+  send = vi.fn();
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("WebsocketConn", () => {
+  it("does not reconnect after disconnect cancels a scheduled reconnect", async () => {
+    const socket = new WebsocketConn("ws://example.test");
+    const connecting = socket.connect();
+    FakeWebSocket.instances[0].onopen?.();
+    await connecting;
+    FakeWebSocket.instances[0].onclose?.();
+
+    socket.disconnect();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("handles duplicate close and error notifications without duplicate reconnects", async () => {
+    const socket = new WebsocketConn("ws://example.test");
+    const connecting = socket.connect();
+    FakeWebSocket.instances[0].onerror?.();
+    await expect(connecting).rejects.toBeUndefined();
+    FakeWebSocket.instances[0].onclose?.();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/action_server/frontend/src/app/RuntimeProviders.tsx
+++ b/action_server/frontend/src/app/RuntimeProviders.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ActionServerContext } from "@/shared/context/actionServerContext";
 import type { ViewSettings } from "@/shared/context/actionServerContext";
@@ -11,13 +11,13 @@ import {
 } from "@/queries/runtime";
 import { subscribeRuntimeEvents } from "@/shared/runtime-events";
 
-export const runtimeQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { staleTime: 30_000, refetchOnWindowFocus: false },
-  },
-});
-
-const ActionServerProvider = ({ children }: { children: ReactNode }) => {
+const ActionServerProvider = ({
+  children,
+  queryClient,
+}: {
+  children: ReactNode;
+  queryClient: QueryClient;
+}) => {
   const [viewSettings, setViewSettings] = useLocalStorage<ViewSettings>(
     "view-settings",
     { theme: "dark" },
@@ -27,8 +27,8 @@ const ActionServerProvider = ({ children }: { children: ReactNode }) => {
   const config = useRuntimeConfig();
 
   useEffect(() => {
-    return subscribeRuntimeEvents(runtimeQueryClient);
-  }, []);
+    return subscribeRuntimeEvents(queryClient);
+  }, [queryClient]);
 
   return (
     <ActionServerContext.Provider
@@ -60,8 +60,23 @@ const ActionServerProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export const RuntimeProviders = ({ children }: { children: ReactNode }) => (
-  <QueryClientProvider client={runtimeQueryClient}>
-    <ActionServerProvider>{children}</ActionServerProvider>
-  </QueryClientProvider>
-);
+export const RuntimeProviders = ({ children }: { children: ReactNode }) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { staleTime: 30_000, refetchOnWindowFocus: false },
+        },
+      }),
+  );
+
+  useEffect(() => () => queryClient.clear(), [queryClient]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ActionServerProvider queryClient={queryClient}>
+        {children}
+      </ActionServerProvider>
+    </QueryClientProvider>
+  );
+};

--- a/action_server/frontend/src/app/RuntimeProviders.tsx
+++ b/action_server/frontend/src/app/RuntimeProviders.tsx
@@ -1,51 +1,33 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  ActionServerContext,
-  defaultActionServerState,
-} from "@/shared/context/actionServerContext";
+import { ActionServerContext } from "@/shared/context/actionServerContext";
 import type { ViewSettings } from "@/shared/context/actionServerContext";
 import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 import {
-  startTrackActions,
-  startTrackRuns,
-  startTrackServerConfig,
-  stopTrackActions,
-  stopTrackRuns,
-  stopTrackServerConfig,
-} from "@/shared/api-client";
-import type {
-  LoadedActionsPackages,
-  LoadedRuns,
-  LoadedServerConfig,
-} from "@/shared/types";
+  useRuntimeActions,
+  useRuntimeConfig,
+  useRuntimeRuns,
+} from "@/queries/runtime";
+import { subscribeRuntimeEvents } from "@/shared/runtime-events";
 
-const queryClient = new QueryClient();
+export const runtimeQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 30_000, refetchOnWindowFocus: false },
+  },
+});
 
 const ActionServerProvider = ({ children }: { children: ReactNode }) => {
   const [viewSettings, setViewSettings] = useLocalStorage<ViewSettings>(
     "view-settings",
     { theme: "dark" },
   );
-  const [loadedRuns, setLoadedRuns] = useState<LoadedRuns>(
-    defaultActionServerState.loadedRuns,
-  );
-  const [loadedActions, setLoadedActions] = useState<LoadedActionsPackages>(
-    defaultActionServerState.loadedActions,
-  );
-  const [loadedServerConfig, setLoadedServerConfig] =
-    useState<LoadedServerConfig>(defaultActionServerState.loadedServerConfig);
+  const actions = useRuntimeActions();
+  const runs = useRuntimeRuns();
+  const config = useRuntimeConfig();
 
   useEffect(() => {
-    startTrackActions(setLoadedActions);
-    startTrackRuns(setLoadedRuns);
-    startTrackServerConfig(setLoadedServerConfig);
-    return () => {
-      stopTrackActions(setLoadedActions);
-      stopTrackRuns(setLoadedRuns);
-      stopTrackServerConfig(setLoadedServerConfig);
-    };
+    return subscribeRuntimeEvents(runtimeQueryClient);
   }, []);
 
   return (
@@ -53,12 +35,24 @@ const ActionServerProvider = ({ children }: { children: ReactNode }) => {
       value={{
         viewSettings,
         setViewSettings,
-        loadedRuns,
-        setLoadedRuns,
-        loadedActions,
-        setLoadedActions,
-        loadedServerConfig,
-        setLoadedServerConfig,
+        loadedRuns: {
+          data: runs.data,
+          isPending: runs.isPending,
+          errorMessage: runs.error?.message,
+        },
+        loadedActions: {
+          data: actions.data,
+          isPending: actions.isPending,
+          errorMessage: actions.error?.message,
+        },
+        loadedServerConfig: {
+          data: config.data,
+          isPending: config.isPending,
+          errorMessage: config.error?.message,
+        },
+        setLoadedRuns: () => undefined,
+        setLoadedActions: () => undefined,
+        setLoadedServerConfig: () => undefined,
       }}
     >
       {children}
@@ -67,7 +61,7 @@ const ActionServerProvider = ({ children }: { children: ReactNode }) => {
 };
 
 export const RuntimeProviders = ({ children }: { children: ReactNode }) => (
-  <QueryClientProvider client={queryClient}>
+  <QueryClientProvider client={runtimeQueryClient}>
     <ActionServerProvider>{children}</ActionServerProvider>
   </QueryClientProvider>
 );

--- a/action_server/frontend/src/core/pages/Actions.tsx
+++ b/action_server/frontend/src/core/pages/Actions.tsx
@@ -28,7 +28,6 @@ import { useActionRunMutation } from '~/queries/actions';
 import { useActionServerContext } from '@/shared/context/actionServerContext';
 import { useWorkItems, useWorkItemStats, useWorkItemQueues, useCreateWorkItem } from '@/queries/workItems';
 import { Select, SelectItem } from '@/core/components/ui/Select';
-import { refreshRuns } from '@/shared/api-client';
 import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
 import { Action, ActionPackage, Run, RunStatus, ServerConfig } from '@/shared/types';
 import { formDataToPayload, propertiesToFormData } from '@/shared/utils/formData';
@@ -468,10 +467,6 @@ export const ActionsPage = () => {
         setRunResult(result);
         setRunError(null);
         
-        // Immediately refresh runs list so the new run appears without waiting for WebSocket
-        refreshRuns().catch(() => {
-          // Silently ignore - WebSocket will eventually update the list
-        });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to run action';
         setRunError(message);

--- a/action_server/frontend/src/core/pages/RunHistory.tsx
+++ b/action_server/frontend/src/core/pages/RunHistory.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/core/components/ui/Button';
@@ -12,7 +13,8 @@ import { Select, SelectItem } from '@/core/components/ui/Select';
 import { useActionServerContext } from '@/shared/context/actionServerContext';
 import { Run, RunStatus } from '@/shared/types';
 import { cn } from '@/shared/utils/cn';
-import { baseUrl, refreshRuns } from '@/shared/api-client';
+import { baseUrl } from '@/shared/api-client';
+import { runtimeQueryKeys } from '@/shared/runtime-query-keys';
 
 // Status styles are now handled by Badge component variants
 
@@ -55,13 +57,14 @@ export const RunHistoryPage = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { loadedRuns, loadedActions } = useActionServerContext();
+  const queryClient = useQueryClient();
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
-      await refreshRuns();
+      await queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.runs() });
     } finally {
       // Short delay to show feedback
       setTimeout(() => setIsRefreshing(false), 300);

--- a/action_server/frontend/src/queries/actions.ts
+++ b/action_server/frontend/src/queries/actions.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { runtimeQueryKeys } from "@/shared/runtime-query-keys";
 
 // Convert string to kebab-case (matches backend URL format)
 const toKebabCase = (str: string): string => {
-  return str.replace(/[\s_]+/g, '-').toLowerCase();
+  return str.replace(/[\s_]+/g, "-").toLowerCase();
 };
 
 export type ActionRunPayload = {
@@ -18,6 +19,7 @@ export type ActionRunPayload = {
 };
 
 export const useActionRunMutation = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({
       actionPackageName,
@@ -41,25 +43,30 @@ export const useActionRunMutation = () => {
         }
       }
 
-      headers['x-action-context'] = btoa(JSON.stringify({ secrets: secretDataAsObject }));
+      headers["x-action-context"] = btoa(
+        JSON.stringify({ secrets: secretDataAsObject }),
+      );
 
       if (requestId) {
-        headers['x-actions-request-id'] = requestId;
+        headers["x-actions-request-id"] = requestId;
       }
 
       // Pass work item queue configuration
       if (workItemQueue) {
-        headers['x-workitem-queue'] = workItemQueue;
+        headers["x-workitem-queue"] = workItemQueue;
       }
 
-      const request = await fetch(`/api/actions/${toKebabCase(actionPackageName)}/${toKebabCase(actionName)}/run`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(args),
-      });
+      const request = await fetch(
+        `/api/actions/${toKebabCase(actionPackageName)}/${toKebabCase(actionName)}/run`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(args),
+        },
+      );
 
-      const runId = request.headers.get('X-Action-Server-Run-Id') || '';
-      let response = '';
+      const runId = request.headers.get("X-Action-Server-Run-Id") || "";
+      let response = "";
 
       try {
         const json = await request.json();
@@ -73,5 +80,7 @@ export const useActionRunMutation = () => {
         response,
       };
     },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.runs() }),
   });
 };

--- a/action_server/frontend/src/queries/runtime.ts
+++ b/action_server/frontend/src/queries/runtime.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  cancelRuntimeRun,
+  getRuntimeConfig,
+  getRuntimeRun,
+  listRuntimeActions,
+  listRuntimeRuns,
+  runRuntimeAction,
+  type RuntimeActionRunRequest,
+} from "@/shared/runtime-api";
+import { runtimeQueryKeys } from "@/shared/runtime-query-keys";
+
+export const useRuntimeActions = () =>
+  useQuery({
+    queryKey: runtimeQueryKeys.actions(),
+    queryFn: ({ signal }) => listRuntimeActions(signal),
+  });
+
+export const useRuntimeRuns = (runType = "all") =>
+  useQuery({
+    queryKey: runtimeQueryKeys.runs(runType),
+    queryFn: ({ signal }) => listRuntimeRuns(runType, signal),
+  });
+
+export const useRuntimeRun = (runId: string) =>
+  useQuery({
+    queryKey: runtimeQueryKeys.run(runId),
+    queryFn: ({ signal }) => getRuntimeRun(runId, signal),
+    enabled: Boolean(runId),
+  });
+
+export const useRuntimeConfig = () =>
+  useQuery({
+    queryKey: runtimeQueryKeys.config(),
+    queryFn: ({ signal }) => getRuntimeConfig(signal),
+  });
+
+export const useRunRuntimeAction = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: RuntimeActionRunRequest) => runRuntimeAction(payload),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.runs() }),
+  });
+};
+
+export const useCancelRuntimeRun = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ runId, signal }: { runId: string; signal?: AbortSignal }) =>
+      cancelRuntimeRun(runId, signal),
+    onSuccess: (_result, { runId }) =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.runs() }),
+        queryClient.invalidateQueries({
+          queryKey: runtimeQueryKeys.run(runId),
+        }),
+      ]),
+  });
+};

--- a/action_server/frontend/src/shared/README.md
+++ b/action_server/frontend/src/shared/README.md
@@ -3,3 +3,9 @@
 Shared utilities used by the Runtime application and future frontend apps.
 
 This includes common types, utilities, and helpers.
+
+Runtime HTTP state is queried through `src/queries/runtime.ts` and keyed by
+`src/shared/runtime-query-keys.ts`. `RuntimeProviders` owns the single
+TanStack `QueryClient`; WebSocket events only invalidate those keys through
+`runtime-events.ts`, so reconnects and stale duplicate events cannot write a
+second or older state store. The Canvas View entrypoint remains independent.

--- a/action_server/frontend/src/shared/api-client.ts
+++ b/action_server/frontend/src/shared/api-client.ts
@@ -8,8 +8,22 @@ export const baseUrl = API_BASE_URL;
 
 interface Opts {
   body?: string;
-  params?: Record<string, string>;
+  params?: Record<string, string | readonly string[]>;
 }
+
+const serializeParams = (
+  params: Record<string, string | readonly string[]>,
+) => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (typeof value === "string") {
+      searchParams.append(key, value);
+    } else {
+      value.forEach((item) => searchParams.append(key, item));
+    }
+  });
+  return searchParams;
+};
 
 type CachedModel<T> = AsyncLoaded<T>;
 
@@ -21,7 +35,7 @@ const loadAsync = async <T>(
 ): Promise<CachedModel<T>> => {
   try {
     let requestURL = url;
-    if (opts?.params) requestURL += `?${new URLSearchParams(opts.params)}`;
+    if (opts?.params) requestURL += `?${serializeParams(opts.params)}`;
     const response = await fetch(requestURL, {
       method,
       headers: {
@@ -49,7 +63,7 @@ const loadAsync = async <T>(
 export const collectRunArtifacts = async (
   runId: string,
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<any>>>,
-  params: Record<string, string>,
+  params: Record<string, string | readonly string[]>,
 ) => {
   setLoaded({ isPending: true, data: undefined });
   setLoaded(
@@ -76,7 +90,7 @@ export const fetchRunArtifactsList = async (
 
 export const collectOAuth2Status = async (
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<any>>>,
-  params: Record<string, string>,
+  params: Record<string, string | readonly string[]>,
 ) => {
   setLoaded({ isPending: true, data: undefined });
   setLoaded(await loadAsync(`${baseUrl}/oauth2/status`, "GET", { params }));

--- a/action_server/frontend/src/shared/api-client.ts
+++ b/action_server/frontend/src/shared/api-client.ts
@@ -1,395 +1,110 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable max-classes-per-file */
 
-import { Dispatch, SetStateAction } from 'react';
-import { API_BASE_URL, WEBSOCKET_BASE_URL } from './constants';
-import {
-  Action,
-  ArtifactInfo,
-  AsyncLoaded,
-  LoadedActionsPackages,
-  LoadedRuns,
-  LoadedServerConfig,
-  Run,
-} from './types';
-import { Counter, copyArrayAndInsertElement, logError } from './utils/helpers';
-import { CachedModel, ModelContainer, ModelType } from './utils/modelContainer';
-import { WebsocketConn } from './utils/websocketConn';
+import { Dispatch, SetStateAction } from "react";
+import { API_BASE_URL } from "./constants";
+import { ArtifactInfo, AsyncLoaded, Run } from "./types";
 
 export const baseUrl = API_BASE_URL;
-export const baseUrlWs = WEBSOCKET_BASE_URL;
 
 interface Opts {
   body?: string;
   params?: Record<string, string>;
 }
 
+type CachedModel<T> = AsyncLoaded<T>;
+
 const loadAsync = async <T>(
   url: string,
-  method: 'POST' | 'GET',
-  opts: Opts | undefined = undefined,
-  headers: HeadersInit | undefined = undefined,
+  method: "POST" | "GET",
+  opts?: Opts,
+  headers?: HeadersInit,
 ): Promise<CachedModel<T>> => {
   try {
-    const body: string | undefined = opts?.body;
-    const params: Record<string, string> | undefined = opts?.params;
     let requestURL = url;
-
-    if (params) {
-      requestURL += `?${new URLSearchParams(params)}`;
-    }
-
-    const fetchArgs: RequestInit = {
+    if (opts?.params) requestURL += `?${new URLSearchParams(opts.params)}`;
+    const response = await fetch(requestURL, {
       method,
       headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
+        Accept: "application/json",
+        "Content-Type": "application/json",
         ...headers,
       },
-    };
-    if (body !== undefined) {
-      fetchArgs.body = body;
-    }
-    const res = await fetch(requestURL, fetchArgs);
-
-    if (!res.ok) {
+      body: opts?.body,
+    });
+    if (!response.ok)
       return {
         isPending: false,
-        data: undefined,
-        errorMessage: `${res.status} (${res.statusText})`,
+        errorMessage: `${response.status} (${response.statusText})`,
       };
-    }
-    const loadedResultAsJson = await res.json();
+    return { isPending: false, data: await response.json() };
+  } catch (error) {
     return {
       isPending: false,
-      data: loadedResultAsJson,
-    };
-  } catch (err) {
-    logError(err);
-    return {
-      isPending: false,
-      data: undefined,
-      errorMessage: err instanceof Error ? err.message : JSON.stringify(err),
+      errorMessage:
+        error instanceof Error ? error.message : JSON.stringify(error),
     };
   }
-};
-
-const globalModelContainer = new ModelContainer();
-
-/**
- * Runs are sorted in descending order as this is the way we
- * should usually iterate over it.
- */
-const sortRuns = (runs: Run[]): void => {
-  runs.sort((a: Run, b: Run) => b.numbered_id - a.numbered_id);
-};
-
-const globalCounter = new Counter();
-
-interface IRequest {
-  method: 'POST' | 'GET';
-  url: string;
-}
-
-interface IResponse<T> {
-  result: T;
-}
-
-class ModelUpdater {
-  private modelContainer: ModelContainer;
-
-  private sio: WebsocketConn;
-
-  private messageIdToHandler = new Map();
-
-  private firstConnect = true;
-
-  constructor(modelContainer: ModelContainer) {
-    this.modelContainer = modelContainer;
-    this.sio = new WebsocketConn(`${baseUrlWs}/api/ws`);
-
-    this.sio.on('echo', () => {
-      // console.log('echo val was', echoVal);
-    });
-
-    this.sio.on('runs_collected', (runs: any) => {
-      // console.log('runs collected', runs);
-      sortRuns(runs);
-
-      this.modelContainer.onModelUpdated(ModelType.RUNS, { isPending: false, data: runs });
-    });
-
-    this.sio.on('run_added', (data: any) => {
-      // console.log('run added', data);
-      const { run } = data;
-      const runsModel = this.modelContainer.getCurrentModel<Run[]>(ModelType.RUNS);
-      // Runs should be reverse ordered by their id.
-      if (runsModel !== undefined && runsModel.data !== undefined && !runsModel.isPending) {
-        // Insert but make sure we keep the (reverse) order.
-        let newRunData;
-        for (let i = 0; i < runsModel.data.length - 1; i += 1) {
-          if (run.numbered_id > runsModel.data[i].numbered_id) {
-            newRunData = copyArrayAndInsertElement(runsModel.data, run, i);
-            break;
-          }
-        }
-        if (newRunData === undefined) {
-          // Case for len==0 or if it was lowest than any existing run.
-          newRunData = runsModel.data.slice();
-          newRunData.push(run);
-        }
-        this.modelContainer.onModelUpdated(ModelType.RUNS, {
-          isPending: false,
-          data: newRunData,
-        });
-      }
-    });
-
-    this.sio.on('run_changed', (run: any) => {
-      // console.log('run changed', run);
-      const runId = run.run_id;
-      const { changes } = run;
-
-      const runsModel = this.modelContainer.getCurrentModel<Run[]>(ModelType.RUNS);
-      if (runsModel !== undefined && runsModel.data !== undefined) {
-        // Runs should be reverse ordered by their id and changes are
-        // usually in the latest runs, so, just iterating to find
-        // that should actually be fast as it should be one
-        // of the first items.
-        for (let i = 0; i < runsModel.data.length; i += 1) {
-          if (runId === runsModel.data[i].id) {
-            const runData = runsModel.data[i];
-            const newRun = { ...runData, ...changes };
-            const newRunData = runsModel.data.slice();
-            newRunData[i] = newRun;
-            this.modelContainer.onModelUpdated(ModelType.RUNS, {
-              isPending: false,
-              data: newRunData,
-            });
-            break;
-          }
-        }
-      }
-    });
-
-    this.sio.on('response', (response: any) => {
-      // console.log('response', response);
-      const messageId = response.message_id;
-      const handler = this.messageIdToHandler.get(messageId);
-      if (handler !== undefined) {
-        this.messageIdToHandler.delete(messageId);
-        handler(response);
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(`Error: no handler for response: ${JSON.stringify(response)}`);
-      }
-    });
-
-    this.sio.on('mtime_changed', () => {
-      // When the server mtime changes, all our data needs to be considered invalid.
-      this.fetchModelsData(false);
-    });
-
-    this.sio.on('connect', () => {
-      if (this.firstConnect) {
-        this.firstConnect = false;
-
-        // On any new connection we have to start listening again
-        // (either being the first or not as new connections later
-        // on probably mean we missed updates).
-        this.sio.emit('start_listen_run_events');
-      } else {
-        // i.e.: the server config is not pushed from the server (because it doesn't change once the
-        // server is started), but if we disconnect and reconnect we need to request it again
-        // (so, on disconnect we set the data to undefined and then request it again).
-        this.fetchModelsData(true);
-      }
-    });
-
-    this.sio.on('disconnect', () => {
-      // Note: if the server is killed/restarted too fast, it's possible that we don't
-      // get a disconnect notification -- we'd just receive a new 'connect' notification.
-      this.modelContainer.onModelUpdated(ModelType.SERVER_CONFIG, {
-        isPending: false,
-        data: undefined,
-      });
-    });
-  }
-
-  private async fetchModelsData(startListening: boolean) {
-    // Load data (actions/runs/config)
-    const loadActionsPromise = loadAsync<Action[]>(`${baseUrl}/api/actionPackages`, 'GET');
-    const loadRunsPromise = loadAsync<Run[]>(`${baseUrl}/api/runs`, 'GET');
-    const loadConfigPromise = loadAsync<Run[]>(`${baseUrl}/config`, 'GET');
-
-    const actions = await loadActionsPromise;
-    const runs = await loadRunsPromise;
-    const config = await loadConfigPromise;
-
-    if (runs.data !== undefined) {
-      sortRuns(runs.data);
-    }
-
-    this.modelContainer.onModelUpdated(ModelType.ACTIONS, actions);
-    this.modelContainer.onModelUpdated(ModelType.RUNS, runs);
-    this.modelContainer.onModelUpdated(ModelType.SERVER_CONFIG, config);
-
-    if (startListening) {
-      // On any new connection we have to start listening again
-      // (either being the first or not as new connections later
-      // on probably mean we missed updates).
-      this.sio.emit('start_listen_run_events');
-    }
-  }
-
-  public async startUpdating() {
-    await this.fetchModelsData(false);
-    // Connect now to automatically start tracking changes.
-    this.sio.connect();
-  }
-
-  public async request<T>(req: IRequest): Promise<IResponse<T>> {
-    let onResolve: (value: IResponse<T>) => void;
-
-    const promise: Promise<IResponse<T>> = new Promise((resolve) => {
-      onResolve = resolve;
-    });
-
-    const messageHandler = (response: IResponse<T>) => {
-      // TODO: See what'd be a response error.
-      onResolve(response);
-    };
-
-    const messageId = globalCounter.next();
-    this.messageIdToHandler.set(messageId, messageHandler);
-    this.sio.emit('request', { method: req.method, url: req.url, message_id: messageId });
-
-    return promise;
-  }
-}
-
-const globalModelUpdater = new ModelUpdater(globalModelContainer);
-globalModelUpdater.startUpdating();
-
-// RUNS
-export const startTrackRuns = (setLoadedRuns: Dispatch<SetStateAction<LoadedRuns>>) => {
-  globalModelContainer.addListener(ModelType.RUNS, setLoadedRuns);
-};
-
-export const stopTrackRuns = (setLoadedRuns: Dispatch<SetStateAction<LoadedRuns>>) => {
-  globalModelContainer.removeListener(ModelType.RUNS, setLoadedRuns);
-};
-
-// ACTIONS
-export const startTrackActions = (
-  setLoadedActions: Dispatch<SetStateAction<LoadedActionsPackages>>,
-) => {
-  globalModelContainer.addListener(ModelType.ACTIONS, setLoadedActions);
-};
-
-export const stopTrackActions = (
-  setLoadedActions: Dispatch<SetStateAction<LoadedActionsPackages>>,
-) => {
-  globalModelContainer.removeListener(ModelType.ACTIONS, setLoadedActions);
-};
-
-// SERVER CONFIG
-export const startTrackServerConfig = (
-  setLoadedServerConfig: Dispatch<SetStateAction<LoadedServerConfig>>,
-) => {
-  globalModelContainer.addListener(ModelType.SERVER_CONFIG, setLoadedServerConfig);
-};
-
-export const stopTrackServerConfig = (
-  setLoadedServerConfig: Dispatch<SetStateAction<LoadedServerConfig>>,
-) => {
-  globalModelContainer.removeListener(ModelType.SERVER_CONFIG, setLoadedServerConfig);
 };
 
 export const collectRunArtifacts = async (
   runId: string,
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<any>>>,
-  params: any,
+  params: Record<string, string>,
 ) => {
-  setLoaded({
-    isPending: true,
-    data: undefined,
-  });
-  const data = await loadAsync<any>(`${baseUrl}/api/runs/${runId}/artifacts/text-content`, 'GET', {
-    params,
-  });
-  setLoaded(data);
+  setLoaded({ isPending: true, data: undefined });
+  setLoaded(
+    await loadAsync(
+      `${baseUrl}/api/runs/${runId}/artifacts/text-content`,
+      "GET",
+      { params },
+    ),
+  );
 };
 
 export const fetchRunArtifactsList = async (
   runId: string,
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<ArtifactInfo[]>>>,
 ) => {
-  setLoaded({
-    isPending: true,
-    data: undefined,
-  });
-  const data = await loadAsync<ArtifactInfo[]>(`${baseUrl}/api/runs/${runId}/artifacts`, 'GET');
-  setLoaded(data);
+  setLoaded({ isPending: true, data: undefined });
+  setLoaded(
+    await loadAsync<ArtifactInfo[]>(
+      `${baseUrl}/api/runs/${runId}/artifacts`,
+      "GET",
+    ),
+  );
 };
 
 export const collectOAuth2Status = async (
   setLoaded: Dispatch<SetStateAction<AsyncLoaded<any>>>,
-  params: any,
+  params: Record<string, string>,
 ) => {
-  setLoaded({
-    isPending: true,
-    data: undefined,
-  });
-  const data = await loadAsync<any>(`${baseUrl}/oauth2/status`, 'GET', {
-    params,
-  });
-  setLoaded(data);
+  setLoaded({ isPending: true, data: undefined });
+  setLoaded(await loadAsync(`${baseUrl}/oauth2/status`, "GET", { params }));
 };
 
 export const cancelRun = async (runId?: string, requestId?: string) => {
-  if (!runId && !requestId) {
-    throw new Error('Either runId or requestId must be provided.');
-  }
-
-  let useRunId: string;
-
-  if (runId) {
-    useRunId = runId;
-  } else {
-    // If we don't have a runId we have to get the run id from the requestId.
-    const run = await loadAsync<any>(
+  if (!runId && !requestId)
+    throw new Error("Either runId or requestId must be provided.");
+  let resolvedRunId = runId;
+  if (!resolvedRunId) {
+    const result = await loadAsync<{ run_id?: string }>(
       `${baseUrl}/api/runs/run-id-from-request-id/${requestId}`,
-      'GET',
+      "GET",
     );
-    useRunId = run?.data?.run_id;
-    if (!useRunId) {
-      throw new Error(`Error getting run id from request id: ${run.errorMessage}`);
-    }
+    resolvedRunId = result.data?.run_id;
+    if (!resolvedRunId)
+      throw new Error(
+        `Error getting run id from request id: ${result.errorMessage}`,
+      );
   }
-  const data = await loadAsync(`${baseUrl}/api/runs/${useRunId}/cancel`, 'POST');
-  return data;
+  return loadAsync(`${baseUrl}/api/runs/${resolvedRunId}/cancel`, "POST");
 };
 
-// Fetch runs with optional run_type filter
 export const fetchRuns = async (runType?: string): Promise<Run[]> => {
-  let url = `${baseUrl}/api/runs`;
-  if (runType && runType !== 'all') {
-    url += `?run_type=${encodeURIComponent(runType)}`;
-  }
-  const result = await loadAsync<Run[]>(url, 'GET');
+  const query =
+    runType && runType !== "all"
+      ? `?run_type=${encodeURIComponent(runType)}`
+      : "";
+  const result = await loadAsync<Run[]>(`${baseUrl}/api/runs${query}`, "GET");
   return result.data || [];
-};
-
-/**
- * Force refresh runs from the server.
- * Call this after running an action to immediately update the runs list
- * without waiting for WebSocket push.
- */
-export const refreshRuns = async (): Promise<void> => {
-  const runs = await loadAsync<Run[]>(`${baseUrl}/api/runs`, 'GET');
-  if (runs.data !== undefined) {
-    sortRuns(runs.data);
-  }
-  globalModelContainer.onModelUpdated(ModelType.RUNS, runs);
 };

--- a/action_server/frontend/src/shared/runtime-api.ts
+++ b/action_server/frontend/src/shared/runtime-api.ts
@@ -1,0 +1,84 @@
+import { API_BASE_URL } from "./constants";
+import type { ActionPackage, Run, ServerConfig } from "./types";
+
+export type RuntimeActionRunRequest = {
+  actionPackageName: string;
+  actionName: string;
+  args: Record<string, unknown>;
+  apiKey?: string;
+  workItemQueue?: string;
+};
+
+export type RuntimeActionRunResponse = {
+  run_id?: string;
+  request_id?: string;
+  [key: string]: unknown;
+};
+
+export class RuntimeApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RuntimeApiError";
+  }
+}
+
+const toKebabCase = (value: string) =>
+  value.replace(/[\s_]+/g, "-").toLowerCase();
+
+const requestJson = async <T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> => {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new RuntimeApiError(
+      response.status,
+      body.detail || body.message || response.statusText,
+    );
+  }
+  return response.json() as Promise<T>;
+};
+
+export const listRuntimeActions = (signal?: AbortSignal) =>
+  requestJson<ActionPackage[]>("/api/actionPackages", { signal });
+
+export const listRuntimeRuns = (runType = "all", signal?: AbortSignal) => {
+  const query =
+    runType === "all" ? "" : `?run_type=${encodeURIComponent(runType)}`;
+  return requestJson<Run[]>(`/api/runs${query}`, { signal });
+};
+
+export const getRuntimeRun = (runId: string, signal?: AbortSignal) =>
+  requestJson<Run>(`/api/runs/${encodeURIComponent(runId)}`, { signal });
+
+export const getRuntimeConfig = (signal?: AbortSignal) =>
+  requestJson<ServerConfig>("/config", { signal });
+
+export const runRuntimeAction = (
+  payload: RuntimeActionRunRequest,
+  signal?: AbortSignal,
+) =>
+  requestJson<RuntimeActionRunResponse>(
+    `/api/actions/${toKebabCase(payload.actionPackageName)}/${toKebabCase(payload.actionName)}/run`,
+    { method: "POST", body: JSON.stringify(payload.args), signal },
+  );
+
+export const cancelRuntimeRun = (runId: string, signal?: AbortSignal) =>
+  requestJson<Record<string, unknown>>(
+    `/api/runs/${encodeURIComponent(runId)}/cancel`,
+    {
+      method: "POST",
+      signal,
+    },
+  );

--- a/action_server/frontend/src/shared/runtime-api.ts
+++ b/action_server/frontend/src/shared/runtime-api.ts
@@ -15,6 +15,8 @@ export type RuntimeActionRunResponse = {
   [key: string]: unknown;
 };
 
+export type CancelRuntimeRunResponse = "cancelled" | "not-running";
+
 export class RuntimeApiError extends Error {
   constructor(
     public readonly status: number,
@@ -75,7 +77,7 @@ export const runRuntimeAction = (
   );
 
 export const cancelRuntimeRun = (runId: string, signal?: AbortSignal) =>
-  requestJson<Record<string, unknown>>(
+  requestJson<CancelRuntimeRunResponse>(
     `/api/runs/${encodeURIComponent(runId)}/cancel`,
     {
       method: "POST",

--- a/action_server/frontend/src/shared/runtime-events.ts
+++ b/action_server/frontend/src/shared/runtime-events.ts
@@ -2,13 +2,14 @@ import type { QueryClient } from "@tanstack/react-query";
 import { runtimeQueryKeys } from "./runtime-query-keys";
 import { WEBSOCKET_BASE_URL } from "./constants";
 import { WebsocketConn } from "./utils/websocketConn";
+import type { Run } from "./types";
 
 export type RuntimeEvent =
-  | { type: "connect" | "mtime_changed"; sequence: number }
-  | { type: "runs_collected" | "run_added"; sequence: number }
+  | { type: "connect" | "mtime_changed" }
+  | { type: "runs_collected"; runs: Run[] }
+  | { type: "run_added"; run: Run }
   | {
       type: "run_changed";
-      sequence: number;
       run_id: string;
       changes: Record<string, unknown>;
     };
@@ -35,14 +36,7 @@ export const applyRuntimeEvent = async (
 };
 
 export const createRuntimeEventAdapter = (queryClient: QueryClient) => {
-  const latestSequence = new Map<string, number>();
   return async (event: RuntimeEvent) => {
-    const identity =
-      event.type === "run_changed"
-        ? `${event.type}:${event.run_id}`
-        : event.type;
-    if ((latestSequence.get(identity) ?? -1) >= event.sequence) return;
-    latestSequence.set(identity, event.sequence);
     return applyRuntimeEvent(queryClient, event);
   };
 };
@@ -50,20 +44,23 @@ export const createRuntimeEventAdapter = (queryClient: QueryClient) => {
 export const subscribeRuntimeEvents = (queryClient: QueryClient) => {
   const socket = new WebsocketConn(`${WEBSOCKET_BASE_URL}/api/ws`);
   const adapter = createRuntimeEventAdapter(queryClient);
-  let sequence = 0;
-  const event =
-    (type: RuntimeEvent["type"]) =>
-    (data?: Omit<RuntimeEvent, "type" | "sequence">) =>
-      adapter({ type, sequence: ++sequence, ...(data ?? {}) } as RuntimeEvent);
 
   socket.on("connect", () => {
-    void adapter({ type: "connect", sequence: ++sequence });
+    void adapter({ type: "connect" });
     void socket.emit("start_listen_run_events");
   });
-  socket.on("runs_collected", event("runs_collected"));
-  socket.on("run_added", event("run_added"));
-  socket.on("run_changed", event("run_changed"));
-  socket.on("mtime_changed", event("mtime_changed"));
+  socket.on("runs_collected", (runs: Run[]) =>
+    adapter({ type: "runs_collected", runs }),
+  );
+  socket.on("run_added", ({ run }: { run: Run }) =>
+    adapter({ type: "run_added", run }),
+  );
+  socket.on(
+    "run_changed",
+    (data: Omit<Extract<RuntimeEvent, { type: "run_changed" }>, "type">) =>
+      adapter({ type: "run_changed", ...data }),
+  );
+  socket.on("mtime_changed", () => adapter({ type: "mtime_changed" }));
   void socket.connect();
   return () => socket.disconnect();
 };

--- a/action_server/frontend/src/shared/runtime-events.ts
+++ b/action_server/frontend/src/shared/runtime-events.ts
@@ -1,0 +1,69 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { runtimeQueryKeys } from "./runtime-query-keys";
+import { WEBSOCKET_BASE_URL } from "./constants";
+import { WebsocketConn } from "./utils/websocketConn";
+
+export type RuntimeEvent =
+  | { type: "connect" | "mtime_changed"; sequence: number }
+  | { type: "runs_collected" | "run_added"; sequence: number }
+  | {
+      type: "run_changed";
+      sequence: number;
+      run_id: string;
+      changes: Record<string, unknown>;
+    };
+
+export const applyRuntimeEvent = async (
+  queryClient: QueryClient,
+  event: RuntimeEvent,
+) => {
+  if (event.type === "run_changed") {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.runs() }),
+      queryClient.invalidateQueries({
+        queryKey: runtimeQueryKeys.run(event.run_id),
+      }),
+    ]);
+    return;
+  }
+  await queryClient.invalidateQueries({
+    queryKey:
+      event.type === "runs_collected" || event.type === "run_added"
+        ? runtimeQueryKeys.runs()
+        : runtimeQueryKeys.root,
+  });
+};
+
+export const createRuntimeEventAdapter = (queryClient: QueryClient) => {
+  const latestSequence = new Map<string, number>();
+  return async (event: RuntimeEvent) => {
+    const identity =
+      event.type === "run_changed"
+        ? `${event.type}:${event.run_id}`
+        : event.type;
+    if ((latestSequence.get(identity) ?? -1) >= event.sequence) return;
+    latestSequence.set(identity, event.sequence);
+    return applyRuntimeEvent(queryClient, event);
+  };
+};
+
+export const subscribeRuntimeEvents = (queryClient: QueryClient) => {
+  const socket = new WebsocketConn(`${WEBSOCKET_BASE_URL}/api/ws`);
+  const adapter = createRuntimeEventAdapter(queryClient);
+  let sequence = 0;
+  const event =
+    (type: RuntimeEvent["type"]) =>
+    (data?: Omit<RuntimeEvent, "type" | "sequence">) =>
+      adapter({ type, sequence: ++sequence, ...(data ?? {}) } as RuntimeEvent);
+
+  socket.on("connect", () => {
+    void adapter({ type: "connect", sequence: ++sequence });
+    void socket.emit("start_listen_run_events");
+  });
+  socket.on("runs_collected", event("runs_collected"));
+  socket.on("run_added", event("run_added"));
+  socket.on("run_changed", event("run_changed"));
+  socket.on("mtime_changed", event("mtime_changed"));
+  void socket.connect();
+  return () => socket.disconnect();
+};

--- a/action_server/frontend/src/shared/runtime-query-keys.ts
+++ b/action_server/frontend/src/shared/runtime-query-keys.ts
@@ -1,0 +1,7 @@
+export const runtimeQueryKeys = {
+  root: ["runtime"] as const,
+  actions: () => ["runtime", "actions"] as const,
+  runs: (runType = "all") => ["runtime", "runs", runType] as const,
+  run: (runId: string) => ["runtime", "run", runId] as const,
+  config: () => ["runtime", "config"] as const,
+};

--- a/action_server/frontend/src/shared/utils/websocketConn.ts
+++ b/action_server/frontend/src/shared/utils/websocketConn.ts
@@ -26,6 +26,10 @@ export class WebsocketConn {
 
   private closed = false;
 
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private generation = 0;
+
   /**
    * Handlers to manage received events.
    */
@@ -109,6 +113,10 @@ export class WebsocketConn {
 
   public connect(): Promise<void> {
     this.closed = false;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.connecting) {
       // console.log('Websocket: connect ignored (already connecting).');
       return Promise.resolve(undefined);
@@ -120,11 +128,13 @@ export class WebsocketConn {
     // console.log('Websocket: starting connection.');
     this.connecting = true;
 
+    const generation = ++this.generation;
     return new Promise((resolve, reject) => {
       // console.log('Websocket: connecting to: ', this.url);
       this.ws = new WebSocket(this.url);
 
       this.ws.onopen = () => {
+        if (generation !== this.generation) return;
         // console.log('Websocket: connection opened (marking as connected)');
         this.connected = true;
         this.connecting = false;
@@ -133,8 +143,9 @@ export class WebsocketConn {
       };
 
       this.ws.onmessage = this.handleMessage;
-      this.ws.onclose = this.handleClose;
+      this.ws.onclose = () => this.handleClose(generation);
       const markNotConnectingAndReject = () => {
+        if (generation !== this.generation) return;
         // console.log('Websocket: connection on error');
         this.connected = false;
         this.connecting = false;
@@ -168,7 +179,8 @@ export class WebsocketConn {
    * is always called even if it doesn't connect
    * (so, it's used as a way to re-connect later on).
    */
-  private handleClose = () => {
+  private handleClose = (generation: number) => {
+    if (generation !== this.generation) return;
     // console.log('closing');
     this.connected = false;
     this.connecting = false;
@@ -177,7 +189,9 @@ export class WebsocketConn {
     // Auto-reconnect quickly as the connection was broken for some reason.
     // Reduced from 5000ms to 1000ms for faster recovery.
     if (!this.closed) {
-      setTimeout(() => {
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        if (this.closed || generation !== this.generation) return;
         this.connect();
       }, 1000);
     }
@@ -185,6 +199,11 @@ export class WebsocketConn {
 
   public disconnect() {
     this.closed = true;
+    this.generation += 1;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.messages = [];
     this.ws?.close();
     this.ws = null;

--- a/action_server/frontend/src/shared/utils/websocketConn.ts
+++ b/action_server/frontend/src/shared/utils/websocketConn.ts
@@ -189,6 +189,7 @@ export class WebsocketConn {
     // Auto-reconnect quickly as the connection was broken for some reason.
     // Reduced from 5000ms to 1000ms for faster recovery.
     if (!this.closed) {
+      if (this.reconnectTimer !== null) return;
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null;
         if (this.closed || generation !== this.generation) return;

--- a/action_server/frontend/src/shared/utils/websocketConn.ts
+++ b/action_server/frontend/src/shared/utils/websocketConn.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { logError } from './helpers';
+import { logError } from "./helpers";
 
 /**
  * A socket.io-like interface for websockets.
@@ -23,6 +23,8 @@ export class WebsocketConn {
    * Flag indicating whether it's currently connecting.
    */
   private connecting = false;
+
+  private closed = false;
 
   /**
    * Handlers to manage received events.
@@ -106,6 +108,7 @@ export class WebsocketConn {
   }
 
   public connect(): Promise<void> {
+    this.closed = false;
     if (this.connecting) {
       // console.log('Websocket: connect ignored (already connecting).');
       return Promise.resolve(undefined);
@@ -125,7 +128,7 @@ export class WebsocketConn {
         // console.log('Websocket: connection opened (marking as connected)');
         this.connected = true;
         this.connecting = false;
-        this.notify('connect');
+        this.notify("connect");
         resolve();
       };
 
@@ -135,7 +138,7 @@ export class WebsocketConn {
         // console.log('Websocket: connection on error');
         this.connected = false;
         this.connecting = false;
-        this.notify('disconnect');
+        this.notify("disconnect");
         reject();
       };
       this.ws.onerror = markNotConnectingAndReject;
@@ -173,8 +176,19 @@ export class WebsocketConn {
 
     // Auto-reconnect quickly as the connection was broken for some reason.
     // Reduced from 5000ms to 1000ms for faster recovery.
-    setTimeout(() => {
-      this.connect();
-    }, 1000);
+    if (!this.closed) {
+      setTimeout(() => {
+        this.connect();
+      }, 1000);
+    }
   };
+
+  public disconnect() {
+    this.closed = true;
+    this.messages = [];
+    this.ws?.close();
+    this.ws = null;
+    this.connected = false;
+    this.connecting = false;
+  }
 }

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -87,6 +87,16 @@ published prerequisites. Never hand-edit lock hashes or add path/direct-URL
 production dependencies. Runtime freeze inputs remain a separate post-candidate
 gate.
 
+The Runtime frontend data-access contract is query-authoritative: typed calls
+in `action_server/frontend/src/shared/runtime-api.ts` feed the canonical keys
+in `src/shared/runtime-query-keys.ts` through `src/queries/runtime.ts`. The
+Runtime provider owns the only `QueryClient`; its WebSocket adapter invalidates
+the same keys and deduplicates older or repeated event sequences without
+writing a parallel mutable store. Focused Vitest coverage exercises list,
+detail, mutation, HTTP error, cancellation, reconnect, and out-of-order event
+paths. Canvas remains a separate Vite entrypoint and is not a consumer of this
+cache.
+
 For a clean source archive, `poetry run invoke devinstall` must discover the
 sibling `actions-http-helper/pyproject.toml`, replace the version requirement
 with that local path before Poetry resolves, and install the helper from the

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -91,11 +91,20 @@ The Runtime frontend data-access contract is query-authoritative: typed calls
 in `action_server/frontend/src/shared/runtime-api.ts` feed the canonical keys
 in `src/shared/runtime-query-keys.ts` through `src/queries/runtime.ts`. The
 Runtime provider owns the only `QueryClient`; its WebSocket adapter invalidates
-the same keys and deduplicates older or repeated event sequences without
-writing a parallel mutable store. Focused Vitest coverage exercises list,
+the same keys without writing a parallel mutable store. Focused Vitest coverage exercises list,
 detail, mutation, HTTP error, cancellation, reconnect, and out-of-order event
 paths. Canvas remains a separate Vite entrypoint and is not a consumer of this
 cache.
+
+The current backend event contract has no sequence field: `runs_collected`
+contains a run list, `run_added` contains `{run}`, and `run_changed` contains
+`{run_id, changes}`. Treat every event as a freshness signal and invalidate
+canonical queries; never apply event payloads directly to cached data. The run
+cancellation endpoint returns the literal union `"cancelled" | "not-running"`.
+Legacy artifact query parameters use repeated keys for readonly string arrays
+(for example, `artifact_names=a&artifact_names=b`). Provider-owned QueryClients
+are created per mounted Runtime provider and cleared during teardown; WebSocket
+reconnect timers are cancelled and guarded against stale connection generations.
 
 For a clean source archive, `poetry run invoke devinstall` must discover the
 sibling `actions-http-helper/pyproject.toml`, replace the version requirement

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -104,7 +104,9 @@ cancellation endpoint returns the literal union `"cancelled" | "not-running"`.
 Legacy artifact query parameters use repeated keys for readonly string arrays
 (for example, `artifact_names=a&artifact_names=b`). Provider-owned QueryClients
 are created per mounted Runtime provider and cleared during teardown; WebSocket
-reconnect timers are cancelled and guarded against stale connection generations.
+reconnect timers are cancelled, single-flight per active connection generation
+even if duplicate close callbacks arrive, and guarded against stale connection
+generations.
 
 For a clean source archive, `poetry run invoke devinstall` must discover the
 sibling `actions-http-helper/pyproject.toml`, replace the version requirement

--- a/docs/superpowers/plans/2026-08-13-runtime-data-access.md
+++ b/docs/superpowers/plans/2026-08-13-runtime-data-access.md
@@ -1,0 +1,55 @@
+# Runtime Data Access Implementation Plan
+
+> **For agentic workers:** Inline execution in the authorized worktree; no delegated writer.
+
+**Goal:** Make Runtime HTTP state typed and canonical in TanStack Query, with WebSocket events acting only as freshness signals.
+
+**Architecture:** Add a small typed Runtime API and stable key module, expose the existing Runtime `QueryClient` as the sole cache authority, and adapt the existing WebSocket events to invalidate or safely update those keys. Keep the existing Runtime context as a compatibility projection for current pages and leave the independent Canvas entrypoint untouched.
+
+**Tech Stack:** React 18, TypeScript, TanStack Query v5, Vitest, existing WebSocket transport.
+
+## Global Constraints
+
+- Scope only frontend Runtime HTTP/query/event paths and focused tests/documentation.
+- Do not add dependencies, change backend contracts, or modify Canvas behavior.
+- Tests precede production changes; preserve `.serena/` and `.codex/`.
+- Keep production changes within the requested path budget.
+
+### Task 1: Typed Runtime contracts and RED acceptance
+
+**Files:**
+- Create: `action_server/frontend/src/shared/runtime-api.test.ts`
+- Create: `action_server/frontend/src/shared/runtime-query-keys.test.ts`
+- Create: `action_server/frontend/src/shared/runtime-events.test.ts`
+
+- [ ] Write tests for typed list/detail/mutation/error/cancellation behavior, stable keys, one cache authority, event freshness, duplicate/out-of-order events, and Runtime/Canvas boundaries.
+- [ ] Run the focused Vitest files and confirm failure because the new modules do not exist.
+
+### Task 2: Implement the canonical Runtime data layer
+
+**Files:**
+- Create: `action_server/frontend/src/shared/runtime-api.ts`
+- Create: `action_server/frontend/src/shared/runtime-query-keys.ts`
+- Create: `action_server/frontend/src/shared/runtime-events.ts`
+- Create: `action_server/frontend/src/queries/runtime.ts`
+- Modify: `action_server/frontend/src/app/RuntimeProviders.tsx`
+- Modify: `action_server/frontend/src/shared/context/actionServerContext.ts`
+- Modify: `action_server/frontend/src/shared/api-client.ts`
+- Modify: `action_server/frontend/src/core/pages/Actions.tsx`
+- Modify: `action_server/frontend/src/core/pages/RunHistory.tsx`
+
+- [ ] Implement typed request/error/signal handling and canonical keys.
+- [ ] Replace the import-time model store with Query-backed context projection and event invalidation.
+- [ ] Route action/run refreshes through the same QueryClient.
+- [ ] Run focused tests and configured frontend checks.
+
+### Task 3: Durable evidence and handoff
+
+**Files:**
+- Modify: `action_server/frontend/src/shared/README.md`
+- Modify: `docs/skills/repository-operations.md`
+- Create: `/tmp/actions-pr110-implementation-receipt.txt`
+
+- [ ] Document only verified Runtime cache/event behavior and exact gates.
+- [ ] Run builds, bundle/artifact checks applicable to the changed Runtime path, `git diff --check`, and inspect the final diff budget.
+- [ ] Commit one descendant, push normally, verify local/remote/PR SHA, and update PR #110 without merging.


### PR DESCRIPTION
Closes #95

## Bounded repair

- Runtime artifact query params model `string | readonly string[]` and serialize arrays as repeated keys.
- Cancellation remains typed to the backend response union: `"cancelled" | "not-running"`.
- Each mounted `RuntimeProviders` owns one isolated QueryClient and clears it on teardown.
- WebSocket reconnect timers are cancelled on disconnect, single-flight per active connection generation, and guarded against stale generations even when duplicate close callbacks arrive.
- Runtime WebSocket events remain freshness signals that invalidate canonical TanStack Query keys without writing parallel state.

## New repair evidence

- Commit: `eb817cdc`
- RED regression on parent `5e72b08e`: duplicate `onclose` callbacks left 2 pending timers; expected 1.
- Focused WebSocket/runtime-event/provider tests: `3` files, `9/9` tests passed.
- `npm run test:quality`: passed.
- `npm run build:runtime`: passed.
- `npm run build:canvas`: passed.
- Runtime and Canvas artifact import validation: passed; size checks reported the repository baseline is unset.
- `git diff --check`: passed.

## Baseline classification

- Full configured Vitest: `210/224` passed; `14` failures remain in the pre-existing untouched Dialog animation and DropdownMenu UI suites. No touched WebSocket/runtime data-access test failed.
- The repository Invoke entrypoint was unavailable in the Poetry environment (`Command not found: invoke`); direct `artifact_validator.py` validation passed for both built roots.

No release workflow or merge was performed.
