### PR TITLE
feat(frontend): refresh the Actions Runtime product shell

### DIFF
--- a/action_server/frontend/README.md
+++ b/action_server/frontend/README.md
@@ -3,13 +3,18 @@
 The frontend has one canonical manifest and lock at this directory. It contains
 two independently buildable application boundaries:
 
-- `apps/runtime` builds the Runtime administration UI and preserves its routes.
+- `apps/runtime` builds the Actions Runtime shell and overview, with navigation
+  limited by the capabilities advertised by `/config`.
 - `apps/canvas-view` builds the separate Canvas View boundary. Product behavior
   for Canvas View is intentionally outside this topology change.
 
 Shared Runtime source lives under `src/`; shell composition is in
 `src/app/RuntimeShell.tsx` and route composition is exposed through
-`src/app/RuntimeRoutes.tsx`.
+`src/app/RuntimeRoutes.tsx`. Runtime HTTP state remains query-authoritative:
+the shell reads the provider-owned TanStack Query data and WebSocket events
+only invalidate those canonical keys. Missing optional capabilities stay
+hidden; unavailable config renders a degraded overview instead of inventing
+metrics or navigation.
 
 ## Install and run
 

--- a/action_server/frontend/README.md
+++ b/action_server/frontend/README.md
@@ -4,7 +4,8 @@ The frontend has one canonical manifest and lock at this directory. It contains
 two independently buildable application boundaries:
 
 - `apps/runtime` builds the Actions Runtime shell and overview, with navigation
-  limited by the capabilities advertised by `/config`.
+  limited to the backend-supported core until `/config` exposes a truthful
+  optional-capability contract.
 - `apps/canvas-view` builds the separate Canvas View boundary. Product behavior
   for Canvas View is intentionally outside this topology change.
 

--- a/action_server/frontend/__tests__/runtime-shell.test.tsx
+++ b/action_server/frontend/__tests__/runtime-shell.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render as rtlRender } from "@testing-library/react";
 import { RuntimeLayout } from "../src/app/RuntimeLayout";
 import { RuntimeRoutes } from "../src/app/RuntimeRoutes";
 import { RuntimeProviders } from "../src/app/RuntimeProviders";
@@ -15,6 +17,35 @@ const runtimeConfig = {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+
+      constructor() {
+        queueMicrotask(() => this.onopen?.());
+      }
+
+      close() {
+        this.onclose?.();
+      }
+
+      send() {}
+    },
+  );
+  const storage = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+  });
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const path = String(input);
     if (path.endsWith("/config")) {
@@ -39,6 +70,17 @@ const renderRuntime = () =>
     </RuntimeProviders>,
   );
 
+const renderRuntimeAt = (path: string) =>
+  rtlRender(
+    <MemoryRouter initialEntries={[path]}>
+      <RuntimeProviders>
+        <RuntimeLayout>
+          <RuntimeRoutes />
+        </RuntimeLayout>
+      </RuntimeProviders>
+    </MemoryRouter>,
+  );
+
 describe("Actions Runtime shell", () => {
   it("identifies the product and lands on a useful overview", async () => {
     renderRuntime();
@@ -49,8 +91,10 @@ describe("Actions Runtime shell", () => {
         screen.getByRole("heading", { name: "Overview" }),
       ).toBeInTheDocument(),
     );
-    expect(screen.getByText("No runs yet")).toBeInTheDocument();
-    expect(screen.getByText("No actions available")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No runs yet")).toBeInTheDocument();
+      expect(screen.getByText("No actions available")).toBeInTheDocument();
+    });
   });
 
   it("keeps optional navigation hidden when the real config has no capabilities", async () => {
@@ -88,5 +132,31 @@ describe("Actions Runtime shell", () => {
     );
     expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
     expect(screen.getAllByText("Actions Runtime").length).toBeGreaterThan(0);
+  });
+
+  it.each(["/schedules", "/robots", "/work-items", "/analytics"])(
+    "redirects unsupported direct link %s to the truthful overview",
+    async (path) => {
+      renderRuntimeAt(path);
+
+      await waitFor(() =>
+        expect(screen.getByRole("heading", { name: "Overview" })).toBeInTheDocument(),
+      );
+      expect(screen.queryByRole("heading", { name: "Schedules" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "Analytics" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Work Items")).not.toBeInTheDocument();
+      expect(screen.queryByText("Robots")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    ["/actions", /No actions available yet/],
+    ["/runs", /No runs recorded yet/],
+    ["/logs/run-1", /was not found in the local cache/],
+    ["/artifacts/run-1", /could not be found/],
+  ])("preserves supported deep link %s", async (path, content) => {
+    renderRuntimeAt(path);
+
+    await waitFor(() => expect(screen.getByText(content)).toBeInTheDocument());
   });
 });

--- a/action_server/frontend/__tests__/runtime-shell.test.tsx
+++ b/action_server/frontend/__tests__/runtime-shell.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { RuntimeLayout } from "../src/app/RuntimeLayout";
+import { RuntimeRoutes } from "../src/app/RuntimeRoutes";
+import { RuntimeProviders } from "../src/app/RuntimeProviders";
+import { render } from "./utils/test-utils";
+
+const runtimeConfig = {
+  expose_url: "http://localhost:8080",
+  auth_enabled: false,
+  version: "1.0.0",
+  mtime_uuid: "runtime-1",
+  capabilities: {
+    actions: true,
+    runs: true,
+    schedules: false,
+    robots: false,
+    work_items: true,
+    analytics: false,
+  },
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const path = String(input);
+    if (path.endsWith("/config")) {
+      return new Response(JSON.stringify(runtimeConfig), { status: 200 });
+    }
+    if (path.includes("/api/actionPackages")) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    if (path.includes("/api/runs")) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    return new Response("Not found", { status: 404 });
+  });
+});
+
+const renderRuntime = () =>
+  render(
+    <RuntimeProviders>
+      <RuntimeLayout>
+        <RuntimeRoutes />
+      </RuntimeLayout>
+    </RuntimeProviders>,
+  );
+
+describe("Actions Runtime shell", () => {
+  it("identifies the product and lands on a useful overview", async () => {
+    renderRuntime();
+
+    expect(screen.getAllByText("Actions Runtime").length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Overview" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("No runs yet")).toBeInTheDocument();
+    expect(screen.getByText("No actions available")).toBeInTheDocument();
+  });
+
+  it("shows only capabilities advertised by the Runtime config", async () => {
+    renderRuntime();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("link", { name: "Work Items" }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("link", { name: "Schedules" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Robots" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Analytics" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a degraded overview when config and data endpoints are unavailable", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("offline"));
+    renderRuntime();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Runtime unavailable" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
+    expect(screen.getByText("Actions Runtime")).toBeInTheDocument();
+  });
+});

--- a/action_server/frontend/__tests__/runtime-shell.test.tsx
+++ b/action_server/frontend/__tests__/runtime-shell.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import { RuntimeLayout } from "../src/app/RuntimeLayout";
 import { RuntimeRoutes } from "../src/app/RuntimeRoutes";
 import { RuntimeProviders } from "../src/app/RuntimeProviders";
@@ -10,14 +11,6 @@ const runtimeConfig = {
   auth_enabled: false,
   version: "1.0.0",
   mtime_uuid: "runtime-1",
-  capabilities: {
-    actions: true,
-    runs: true,
-    schedules: false,
-    robots: false,
-    work_items: true,
-    analytics: false,
-  },
 };
 
 beforeEach(() => {
@@ -60,14 +53,16 @@ describe("Actions Runtime shell", () => {
     expect(screen.getByText("No actions available")).toBeInTheDocument();
   });
 
-  it("shows only capabilities advertised by the Runtime config", async () => {
+  it("keeps optional navigation hidden when the real config has no capabilities", async () => {
     renderRuntime();
 
     await waitFor(() =>
-      expect(
-        screen.getByRole("link", { name: "Work Items" }),
-      ).toBeInTheDocument(),
+      expect(screen.getByRole("link", { name: "Actions" })).toBeInTheDocument(),
     );
+    expect(screen.getByRole("link", { name: "Runs" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Work Items" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Schedules" }),
     ).not.toBeInTheDocument();
@@ -80,7 +75,10 @@ describe("Actions Runtime shell", () => {
   });
 
   it("renders a degraded overview when config and data endpoints are unavailable", async () => {
-    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("offline"));
+    vi.mocked(globalThis.fetch).mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ detail: "offline" }), { status: 503 }),
+    );
     renderRuntime();
 
     await waitFor(() =>
@@ -89,6 +87,6 @@ describe("Actions Runtime shell", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
-    expect(screen.getByText("Actions Runtime")).toBeInTheDocument();
+    expect(screen.getAllByText("Actions Runtime").length).toBeGreaterThan(0);
   });
 });

--- a/action_server/frontend/apps/runtime/index.html
+++ b/action_server/frontend/apps/runtime/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Action Server</title>
+    <title>Actions Runtime</title>
   </head>
   <body>
     <div id="root"></div>

--- a/action_server/frontend/src/app/RuntimeLayout.tsx
+++ b/action_server/frontend/src/app/RuntimeLayout.tsx
@@ -1,9 +1,26 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { RuntimeNavigation } from "./RuntimeNavigation";
 
-export const RuntimeLayout = ({ children }: { children: ReactNode }) => (
-  <div className="flex min-h-screen bg-background">
-    <RuntimeNavigation />
-    <main className="flex-1 overflow-auto">{children}</main>
-  </div>
-);
+export const RuntimeLayout = ({ children }: { children: ReactNode }) => {
+  const [mobileNavigationOpen, setMobileNavigationOpen] = useState(false);
+  return (
+    <div className="flex min-h-screen bg-background">
+      <div id="runtime-navigation">
+        <RuntimeNavigation isMobileOpen={mobileNavigationOpen} />
+      </div>
+      <main className="min-w-0 flex-1 overflow-auto">
+        <button
+          type="button"
+          className="m-3 rounded-md border border-border px-3 py-2 text-sm md:hidden"
+          onClick={() => setMobileNavigationOpen(!mobileNavigationOpen)}
+          aria-expanded={mobileNavigationOpen}
+          aria-controls="runtime-navigation"
+        >
+          Menu
+        </button>
+        {children}
+      </main>
+    </div>
+  );
+};

--- a/action_server/frontend/src/app/RuntimeNavigation.tsx
+++ b/action_server/frontend/src/app/RuntimeNavigation.tsx
@@ -2,7 +2,6 @@ import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/shared/utils/cn";
 import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 import { useTheme } from "@/shared/hooks/useTheme";
-import { useActionServerContext } from "@/shared/context/actionServerContext";
 
 const items = [
   ["Overview", "/overview", "overview"],
@@ -20,23 +19,13 @@ export const RuntimeNavigation = ({
   isMobileOpen?: boolean;
 }) => {
   const location = useLocation();
-  const { loadedServerConfig } = useActionServerContext();
   const [isCollapsed, setIsCollapsed] = useLocalStorage(
     "sidebar-collapsed",
     false,
   );
   const { theme, cycleTheme } = useTheme();
-  const capabilities = loadedServerConfig.data?.capabilities;
   const visibleItems = items.filter(([, , capability]) => {
     if (capability === "overview") return true;
-    if (capabilities) {
-      const enabled = capabilities[capability as keyof typeof capabilities];
-      return (
-        enabled === true ||
-        (enabled === undefined &&
-          (capability === "actions" || capability === "runs"))
-      );
-    }
     return capability === "actions" || capability === "runs";
   });
   return (

--- a/action_server/frontend/src/app/RuntimeNavigation.tsx
+++ b/action_server/frontend/src/app/RuntimeNavigation.tsx
@@ -2,28 +2,49 @@ import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/shared/utils/cn";
 import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 import { useTheme } from "@/shared/hooks/useTheme";
+import { useActionServerContext } from "@/shared/context/actionServerContext";
 
 const items = [
-  ["Actions", "/actions"],
-  ["Runs", "/runs"],
-  ["Schedules", "/schedules"],
-  ["Robots", "/robots"],
-  ["Work Items", "/work-items"],
-  ["Analytics", "/analytics"],
+  ["Overview", "/overview", "overview"],
+  ["Actions", "/actions", "actions"],
+  ["Runs", "/runs", "runs"],
+  ["Schedules", "/schedules", "schedules"],
+  ["Robots", "/robots", "robots"],
+  ["Work Items", "/work-items", "work_items"],
+  ["Analytics", "/analytics", "analytics"],
 ] as const;
 
-export const RuntimeNavigation = () => {
+export const RuntimeNavigation = ({
+  isMobileOpen = false,
+}: {
+  isMobileOpen?: boolean;
+}) => {
   const location = useLocation();
+  const { loadedServerConfig } = useActionServerContext();
   const [isCollapsed, setIsCollapsed] = useLocalStorage(
     "sidebar-collapsed",
     false,
   );
   const { theme, cycleTheme } = useTheme();
+  const capabilities = loadedServerConfig.data?.capabilities;
+  const visibleItems = items.filter(([, , capability]) => {
+    if (capability === "overview") return true;
+    if (capabilities) {
+      const enabled = capabilities[capability as keyof typeof capabilities];
+      return (
+        enabled === true ||
+        (enabled === undefined &&
+          (capability === "actions" || capability === "runs"))
+      );
+    }
+    return capability === "actions" || capability === "runs";
+  });
   return (
     <aside
       className={cn(
         "sidebar flex flex-col border-r border-sidebar-border/50 transition-all duration-200",
         isCollapsed ? "w-16" : "w-64",
+        isMobileOpen && "open",
       )}
     >
       <div
@@ -34,7 +55,7 @@ export const RuntimeNavigation = () => {
       >
         {!isCollapsed && (
           <span className="text-base font-semibold text-sidebar-foreground">
-            Action Server
+            Actions Runtime
           </span>
         )}
         <button
@@ -66,7 +87,7 @@ export const RuntimeNavigation = () => {
         className={cn("flex-1 space-y-1 py-2", isCollapsed ? "px-2" : "px-3")}
         aria-label="Runtime navigation"
       >
-        {items.map(([label, path]) => (
+        {visibleItems.map(([label, path]) => (
           <Link
             key={path}
             to={path}

--- a/action_server/frontend/src/app/RuntimeProviders.tsx
+++ b/action_server/frontend/src/app/RuntimeProviders.tsx
@@ -65,7 +65,11 @@ export const RuntimeProviders = ({ children }: { children: ReactNode }) => {
     () =>
       new QueryClient({
         defaultOptions: {
-          queries: { staleTime: 30_000, refetchOnWindowFocus: false },
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+            retry: false,
+          },
         },
       }),
   );

--- a/action_server/frontend/src/app/RuntimeRoutes.tsx
+++ b/action_server/frontend/src/app/RuntimeRoutes.tsx
@@ -1,12 +1,8 @@
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { ActionsPage } from "@/core/pages/Actions";
-import { AnalyticsPage } from "@/core/pages/Analytics";
 import { ArtifactsPage } from "@/core/pages/Artifacts";
 import { LogsPage } from "@/core/pages/Logs";
-import { RobotsPage } from "@/core/pages/Robots";
 import { RunHistoryPage } from "@/core/pages/RunHistory";
-import { SchedulesPage } from "@/core/pages/Schedules";
-import { WorkItemsPage } from "@/core/pages/WorkItems";
 import { OverviewPage } from "@/core/pages/Overview";
 
 export const RuntimeRoutes = () => {
@@ -18,10 +14,20 @@ export const RuntimeRoutes = () => {
         <Route path="/overview" element={<OverviewPage />} />
         <Route path="/actions" element={<ActionsPage />} />
         <Route path="/runs" element={<RunHistoryPage />} />
-        <Route path="/schedules" element={<SchedulesPage />} />
-        <Route path="/robots" element={<RobotsPage />} />
-        <Route path="/work-items" element={<WorkItemsPage />} />
-        <Route path="/analytics" element={<AnalyticsPage />} />
+        {/* Optional routes stay fail-closed until /config exposes capabilities. */}
+        <Route
+          path="/schedules"
+          element={<Navigate to="/overview" replace />}
+        />
+        <Route path="/robots" element={<Navigate to="/overview" replace />} />
+        <Route
+          path="/work-items"
+          element={<Navigate to="/overview" replace />}
+        />
+        <Route
+          path="/analytics"
+          element={<Navigate to="/overview" replace />}
+        />
         <Route path="/logs/:runId" element={<LogsPage />} />
         <Route path="/artifacts/:runId" element={<ArtifactsPage />} />
         <Route path="*" element={<Navigate to="/overview" replace />} />

--- a/action_server/frontend/src/app/RuntimeRoutes.tsx
+++ b/action_server/frontend/src/app/RuntimeRoutes.tsx
@@ -7,13 +7,15 @@ import { RobotsPage } from "@/core/pages/Robots";
 import { RunHistoryPage } from "@/core/pages/RunHistory";
 import { SchedulesPage } from "@/core/pages/Schedules";
 import { WorkItemsPage } from "@/core/pages/WorkItems";
+import { OverviewPage } from "@/core/pages/Overview";
 
 export const RuntimeRoutes = () => {
   const location = useLocation();
   return (
     <div key={location.pathname} className="page-transition-wrapper h-full">
       <Routes location={location}>
-        <Route path="/" element={<Navigate to="/actions" replace />} />
+        <Route path="/" element={<Navigate to="/overview" replace />} />
+        <Route path="/overview" element={<OverviewPage />} />
         <Route path="/actions" element={<ActionsPage />} />
         <Route path="/runs" element={<RunHistoryPage />} />
         <Route path="/schedules" element={<SchedulesPage />} />
@@ -22,7 +24,7 @@ export const RuntimeRoutes = () => {
         <Route path="/analytics" element={<AnalyticsPage />} />
         <Route path="/logs/:runId" element={<LogsPage />} />
         <Route path="/artifacts/:runId" element={<ArtifactsPage />} />
-        <Route path="*" element={<Navigate to="/actions" replace />} />
+        <Route path="*" element={<Navigate to="/overview" replace />} />
       </Routes>
     </div>
   );

--- a/action_server/frontend/src/core/pages/Overview.tsx
+++ b/action_server/frontend/src/core/pages/Overview.tsx
@@ -1,0 +1,112 @@
+import { Link } from "react-router-dom";
+import { useActionServerContext } from "@/shared/context/actionServerContext";
+
+export const OverviewPage = () => {
+  const { loadedActions, loadedRuns, loadedServerConfig } =
+    useActionServerContext();
+  const unavailable = Boolean(loadedServerConfig.errorMessage);
+  const dataUnavailable = Boolean(
+    loadedActions.errorMessage || loadedRuns.errorMessage,
+  );
+  const loading =
+    loadedActions.isPending ||
+    loadedRuns.isPending ||
+    loadedServerConfig.isPending;
+
+  if (unavailable) {
+    return (
+      <section
+        className="mx-auto max-w-5xl p-6"
+        aria-labelledby="runtime-unavailable-title"
+      >
+        <p className="text-sm font-medium text-muted-foreground">
+          Actions Runtime
+        </p>
+        <h1
+          id="runtime-unavailable-title"
+          className="mt-2 text-3xl font-semibold"
+        >
+          Runtime unavailable
+        </h1>
+        <p className="mt-3 max-w-xl text-muted-foreground">
+          Runtime configuration could not be loaded. Check the server connection
+          and try again.
+        </p>
+      </section>
+    );
+  }
+
+  if (dataUnavailable) {
+    return (
+      <section
+        className="mx-auto max-w-5xl p-6"
+        aria-labelledby="overview-data-unavailable-title"
+      >
+        <p className="text-sm font-medium text-muted-foreground">
+          Actions Runtime
+        </p>
+        <h1
+          id="overview-data-unavailable-title"
+          className="mt-2 text-3xl font-semibold"
+        >
+          Overview data unavailable
+        </h1>
+        <p className="mt-3 max-w-xl text-muted-foreground">
+          Some Runtime data could not be loaded. The navigation remains
+          available for supported capabilities.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto max-w-5xl p-6" aria-labelledby="overview-title">
+      <header className="mb-8">
+        <p className="text-sm font-medium text-muted-foreground">
+          Actions Runtime
+        </p>
+        <h1 id="overview-title" className="mt-2 text-3xl font-semibold">
+          Overview
+        </h1>
+        <p className="mt-3 max-w-2xl text-muted-foreground">
+          See what is available in this Runtime and get to the work that
+          matters.
+        </p>
+      </header>
+      {loading ? (
+        <p role="status" className="text-muted-foreground">
+          Loading Runtime data…
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            to="/actions"
+            className="rounded-xl border border-border p-5 transition-colors hover:bg-muted/50 focus-ring"
+          >
+            <h2 className="font-medium">Actions</h2>
+            <p className="mt-2 text-2xl font-semibold">
+              {loadedActions.data?.length ?? 0}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {loadedActions.data?.length
+                ? "Available action packages"
+                : "No actions available"}
+            </p>
+          </Link>
+          <Link
+            to="/runs"
+            className="rounded-xl border border-border p-5 transition-colors hover:bg-muted/50 focus-ring"
+          >
+            <h2 className="font-medium">Runs</h2>
+            <p className="mt-2 text-2xl font-semibold">
+              {loadedRuns.data?.length ?? 0}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {loadedRuns.data?.length ? "Recent Runtime runs" : "No runs yet"}
+            </p>
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/action_server/frontend/src/shared/types.ts
+++ b/action_server/frontend/src/shared/types.ts
@@ -86,16 +86,6 @@ export type ServerConfig = {
   auth_enabled: boolean;
   version: string; // The version for the action server (if it changes a full window reload would be needed).
   mtime_uuid: string; // The mtime of the action server (if it changes all data needs to be reloaded).
-  capabilities?: RuntimeCapabilities;
-};
-
-export type RuntimeCapabilities = {
-  actions?: boolean;
-  runs?: boolean;
-  schedules?: boolean;
-  robots?: boolean;
-  work_items?: boolean;
-  analytics?: boolean;
 };
 
 // Robot Catalog Types

--- a/action_server/frontend/src/shared/types.ts
+++ b/action_server/frontend/src/shared/types.ts
@@ -86,6 +86,16 @@ export type ServerConfig = {
   auth_enabled: boolean;
   version: string; // The version for the action server (if it changes a full window reload would be needed).
   mtime_uuid: string; // The mtime of the action server (if it changes all data needs to be reloaded).
+  capabilities?: RuntimeCapabilities;
+};
+
+export type RuntimeCapabilities = {
+  actions?: boolean;
+  runs?: boolean;
+  schedules?: boolean;
+  robots?: boolean;
+  work_items?: boolean;
+  analytics?: boolean;
 };
 
 // Robot Catalog Types

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -182,10 +182,13 @@ The Runtime shell overview reads the provider-owned config/actions/runs queries;
 it does not create a second cache or invent metrics. The current backend `/config`
 payload has no capability metadata, so optional navigation remains hidden and
 only Overview, Actions, and Runs are exposed until a truthful capability source
-is implemented. A config failure renders a degraded overview and leaves only
-safe overview/core navigation visible; Runtime queries disable retries so that
-failure state is observable promptly. The Runtime entry document is titled
-`Actions Runtime`; Canvas View remains an independent entrypoint.
+is implemented. Navigation visibility and route reachability must use the same
+truthful capability contract: hiding an item is not route authorization, and
+unsupported optional direct links must fall back to Overview. A config failure
+renders a degraded overview and leaves only safe overview/core navigation
+visible; Runtime queries disable retries so that failure state is observable
+promptly. The Runtime entry document is titled `Actions Runtime`; Canvas View
+remains an independent entrypoint.
 
 The current backend event contract has no sequence field: `runs_collected`
 contains a run list, `run_added` contains `{run}`, and `run_changed` contains

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -178,6 +178,14 @@ detail, mutation, HTTP error, cancellation, reconnect, and out-of-order event
 paths. Canvas remains a separate Vite entrypoint and is not a consumer of this
 cache.
 
+The Runtime shell overview reads the provider-owned config/actions/runs queries;
+it does not create a second cache or invent metrics. `/config.capabilities`
+controls optional navigation: absent optional flags remain hidden, while the
+core Actions and Runs surfaces retain compatibility when the capability object
+is omitted. A config failure renders a degraded overview and leaves only safe
+overview/core navigation visible. The Runtime entry document is titled
+`Actions Runtime`; Canvas View remains an independent entrypoint.
+
 The current backend event contract has no sequence field: `runs_collected`
 contains a run list, `run_added` contains `{run}`, and `run_changed` contains
 `{run_id, changes}`. Treat every event as a freshness signal and invalidate

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -179,11 +179,12 @@ paths. Canvas remains a separate Vite entrypoint and is not a consumer of this
 cache.
 
 The Runtime shell overview reads the provider-owned config/actions/runs queries;
-it does not create a second cache or invent metrics. `/config.capabilities`
-controls optional navigation: absent optional flags remain hidden, while the
-core Actions and Runs surfaces retain compatibility when the capability object
-is omitted. A config failure renders a degraded overview and leaves only safe
-overview/core navigation visible. The Runtime entry document is titled
+it does not create a second cache or invent metrics. The current backend `/config`
+payload has no capability metadata, so optional navigation remains hidden and
+only Overview, Actions, and Runs are exposed until a truthful capability source
+is implemented. A config failure renders a degraded overview and leaves only
+safe overview/core navigation visible; Runtime queries disable retries so that
+failure state is observable promptly. The Runtime entry document is titled
 `Actions Runtime`; Canvas View remains an independent entrypoint.
 
 The current backend event contract has no sequence field: `runs_collected`


### PR DESCRIPTION
Closes #96

## Scope

Actions Runtime shell/overview only. No merge performed.

- Runtime identity and `/overview` remain in the existing Runtime entrypoint.
- Backend `/config` was traced in `action_server/src/actions/server/_server.py`: it emits `expose_url`, `auth_enabled`, `version`, and route-added `mtime_uuid`; it does not emit `capabilities`.
- Removed the fabricated frontend `config.capabilities` contract. With the real payload, optional navigation stays hidden and core Overview/Actions/Runs remain available.
- Runtime query retries are disabled so configuration failures reach the degraded state promptly.
- Canvas remains a separate entrypoint and was not modified.

## Verified at `4c794c4756c6d24f353f0f875c705f6b159c443d`

- Node `v20.19.0`; `npm ci`: passed, 624 packages installed in `/dev/shm`.
- Focused shell Vitest: 3/3 passed.
- `npm run test:quality`: passed: lint, TypeScript, Prettier, topology 6/6.
- Runtime build: passed; `dist/index.html` 939.64 kB.
- Canvas build: passed; `dist-canvas/index.html` 144.08 kB.
- Direct artifact import validation: passed for Runtime and Canvas.
- Built Runtime browser evidence: authentic desktop dark, desktop light, and constrained mobile error-state screenshots; mobile menu and keyboard focus were inspected.
- `git diff --check`: passed. Local, remote, and PR head all equal `4c794c4756c6d24f353f0f875c705f6b159c443d`.

## Limits

- Complete Vitest ran 213/227; 14 failures are confined to untouched Dialog/DropdownMenu design-system tests owned by #97. No #97 changes were made.
- Repository `inv` is unavailable on the host, so the canonical Invoke artifact/integrity gate is unverified. Direct validator checks passed; host pytest is unavailable.
- No backend fixture was available for truthful loaded/empty/capability browser screenshots. Offline reload reached the browser network-error page because the static artifact had no backend. Lighthouse, CSP headers, and forced reduced-motion browser evidence remain unverified.
- npm audit reported 21 dependency advisories from the existing lock install; no dependency or lockfile changes were made.

Independent review and merge remain outside this lane.
