### PR TITLE
feat: add revisioned MCP catalogs

### DIFF
--- a/action_server/src/actions/server/mcp/setup_mcp_server_v2.py
+++ b/action_server/src/actions/server/mcp/setup_mcp_server_v2.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Literal
+from hashlib import sha256
+from typing import Any, Literal
 
 from mcp.types import (
     CallToolResult,
@@ -24,6 +26,9 @@ from mcp.types import (
 )
 
 log = logging.getLogger(__name__)
+CATALOG_REVISION_META_KEY = "actions.catalogRevision"
+CATALOG_TTL_MS = 0
+CATALOG_CACHE_SCOPE = "private"
 OutputSchemaKind = Literal["string", "object", "wrap-in-result-object"]
 
 
@@ -69,7 +74,9 @@ class McpServerSetupHelper:
         return dict(request.headers), dict(request.cookies)
 
     async def _list_tools(self, _ctx: Any, _params: Any) -> ListToolsResult:
-        return ListToolsResult(tools=list(self._tools))
+        return ListToolsResult(
+            tools=list(self._tools), **self._catalog_result_metadata()
+        )
 
     async def _call_tool(self, ctx: Any, params: Any):
         try:
@@ -107,13 +114,19 @@ class McpServerSetupHelper:
             raise
 
     async def _list_resources(self, _ctx: Any, _params: Any) -> ListResourcesResult:
-        return ListResourcesResult(resources=list(self._resources.values()))
+        return ListResourcesResult(
+            resources=sorted(self._resources.values(), key=lambda item: str(item.uri)),
+            **self._catalog_result_metadata(),
+        )
 
     async def _list_resource_templates(
         self, _ctx: Any, _params: Any
     ) -> ListResourceTemplatesResult:
         return ListResourceTemplatesResult(
-            resource_templates=list(self._resource_templates)
+            resource_templates=sorted(
+                self._resource_templates, key=lambda item: item.uri_template
+            ),
+            **self._catalog_result_metadata(),
         )
 
     async def _read_resource(self, ctx: Any, params: Any) -> ReadResourceResult:
@@ -164,7 +177,43 @@ class McpServerSetupHelper:
         )
 
     async def _list_prompts(self, _ctx: Any, _params: Any) -> ListPromptsResult:
-        return ListPromptsResult(prompts=list(self._prompts))
+        return ListPromptsResult(
+            prompts=list(self._prompts), **self._catalog_result_metadata()
+        )
+
+    @property
+    def catalog_revision(self) -> str:
+        catalog = {
+            "prompts": [
+                item.model_dump(by_alias=True, mode="json", exclude_none=True)
+                for item in sorted(self._prompts, key=lambda item: item.name)
+            ],
+            "resources": [
+                item.model_dump(by_alias=True, mode="json", exclude_none=True)
+                for item in sorted(
+                    self._resources.values(), key=lambda item: str(item.uri)
+                )
+            ],
+            "resourceTemplates": [
+                item.model_dump(by_alias=True, mode="json", exclude_none=True)
+                for item in sorted(
+                    self._resource_templates, key=lambda item: item.uri_template
+                )
+            ],
+            "tools": [
+                item.model_dump(by_alias=True, mode="json", exclude_none=True)
+                for item in sorted(self._tools, key=lambda item: item.name)
+            ],
+        }
+        canonical = json.dumps(catalog, sort_keys=True, separators=(",", ":"))
+        return sha256(canonical.encode("utf-8")).hexdigest()
+
+    def _catalog_result_metadata(self) -> dict[str, Any]:
+        return {
+            "_meta": {CATALOG_REVISION_META_KEY: self.catalog_revision},
+            "ttlMs": CATALOG_TTL_MS,
+            "cacheScope": CATALOG_CACHE_SCOPE,
+        }
 
     async def _get_prompt(self, ctx: Any, params: Any) -> GetPromptResult:
         action_info = self._prompt_name_to_action_info[params.name]
@@ -222,6 +271,7 @@ class McpServerSetupHelper:
                 self._resource_template_to_action_info[uri] = ActionInfo(
                     func, action, display_name, doc_desc, "string", mcp_meta
                 )
+                self._resource_templates.sort(key=lambda item: item.uri_template)
             else:
                 resource_uri = uri
                 self._resources[resource_uri] = Resource(
@@ -257,6 +307,7 @@ class McpServerSetupHelper:
             self._prompt_name_to_action_info[action.name] = ActionInfo(
                 func, action, display_name, doc_desc, "string", mcp_meta
             )
+            self._prompts.sort(key=lambda item: item.name)
             return
 
         output_schema = json.loads(action.output_schema)
@@ -292,6 +343,7 @@ class McpServerSetupHelper:
         self._tool_name_to_action_info[action.name] = ActionInfo(
             func, action, display_name, doc_desc, output_schema_kind, mcp_meta
         )
+        self._tools.sort(key=lambda item: item.name)
 
     def unregister_actions(self) -> None:
         self._init_state()

--- a/action_server/src/actions/server/mcp/setup_mcp_server_v2.py
+++ b/action_server/src/actions/server/mcp/setup_mcp_server_v2.py
@@ -259,6 +259,8 @@ class McpServerSetupHelper:
             if not uri:
                 raise ValueError(f"Resource {action.name} has no URI")
             if "{" in uri and "}" in uri:
+                if uri in self._resource_template_to_action_info:
+                    raise ValueError(f"duplicate resource template URI: {uri}")
                 self._resource_templates.append(
                     ResourceTemplate(
                         uri_template=uri,
@@ -274,6 +276,8 @@ class McpServerSetupHelper:
                 self._resource_templates.sort(key=lambda item: item.uri_template)
             else:
                 resource_uri = uri
+                if resource_uri in self._resources:
+                    raise ValueError(f"duplicate resource URI: {resource_uri}")
                 self._resources[resource_uri] = Resource(
                     uri=resource_uri,
                     name=action.name,
@@ -287,6 +291,8 @@ class McpServerSetupHelper:
                 )
             return
         if kind == "prompt":
+            if action.name in self._prompt_name_to_action_info:
+                raise ValueError(f"duplicate prompt name: {action.name}")
             schema = json.loads(action.input_schema)
             required = schema.get("required", [])
             self._prompts.append(
@@ -310,6 +316,8 @@ class McpServerSetupHelper:
             self._prompts.sort(key=lambda item: item.name)
             return
 
+        if action.name in self._tool_name_to_action_info:
+            raise ValueError(f"duplicate tool name: {action.name}")
         output_schema = json.loads(action.output_schema)
         if output_schema.get("type") == "string":
             output_schema_kind: OutputSchemaKind = "string"

--- a/action_server/tests/action_server_tests/mcp/test_mcp_integration.py
+++ b/action_server/tests/action_server_tests/mcp/test_mcp_integration.py
@@ -886,11 +886,16 @@ def prompt_{suffix}() -> str:
         additional_args=["--auto-reload"],
     )
 
-    async def catalog_names() -> dict[str, list[str]]:
+    async def catalog_names() -> dict[str, object]:
         base_url = f"http://localhost:{action_server_process.port}/mcp"
         tools = await _post_modern_mcp(base_url, "tools/list", 1)
         resources = await _post_modern_mcp(base_url, "resources/list", 2)
         prompts = await _post_modern_mcp(base_url, "prompts/list", 3)
+        revisions = {
+            result["_meta"]["actions.catalogRevision"]
+            for result in (tools, resources, prompts)
+        }
+        assert len(revisions) == 1
         for result in (tools, resources, prompts):
             assert result["ttlMs"] == 0
             assert result["cacheScope"] == "private"
@@ -898,20 +903,26 @@ def prompt_{suffix}() -> str:
             "tools": [tool["name"] for tool in tools["tools"]],
             "resources": [resource["uri"] for resource in resources["resources"]],
             "prompts": [prompt["name"] for prompt in prompts["prompts"]],
+            "revision": revisions.pop(),
         }
 
-    assert run_async_in_new_thread(catalog_names) == {
+    before = run_async_in_new_thread(catalog_names)
+    assert before == {
         "tools": ["tool_before"],
         "resources": ["catalog://before"],
         "prompts": ["prompt_before"],
+        "revision": before["revision"],
     }
     write_catalog("after")
 
     def assert_fresh_catalogs() -> None:
-        assert run_async_in_new_thread(catalog_names) == {
+        after = run_async_in_new_thread(catalog_names)
+        assert after == {
             "tools": ["tool_after"],
             "resources": ["catalog://after"],
             "prompts": ["prompt_after"],
+            "revision": after["revision"],
         }
+        assert after["revision"] != before["revision"]
 
     wait_for_non_error_condition(assert_fresh_catalogs)

--- a/action_server/tests/action_server_tests/mcp/test_mcp_integration.py
+++ b/action_server/tests/action_server_tests/mcp/test_mcp_integration.py
@@ -926,3 +926,90 @@ def prompt_{suffix}() -> str:
         assert after["revision"] != before["revision"]
 
     wait_for_non_error_condition(assert_fresh_catalogs)
+
+
+@pytest.mark.integration_test
+def test_mcp_catalog_revisions_match_across_independent_runtime_processes(
+    tmpdir,
+) -> None:
+    """Independent Runtime processes fingerprint equivalent surfaces alike."""
+    from pathlib import Path
+
+    from action_server_tests.fixtures import run_async_in_new_thread
+
+    def write_catalog(directory: Path, *, reverse: bool, differing: bool) -> None:
+        definitions = [
+            '''@mcp.tool()\ndef alpha() -> str:\n    """Alpha tool."""\n    return "alpha"\n''',
+            '''@mcp.resource("catalog://direct")\ndef direct_resource() -> str:\n    """Direct resource."""\n    return "direct"\n''',
+            '''@mcp.resource("catalog://{item}")\ndef templated_resource(item: str) -> str:\n    """Templated resource."""\n    return item\n''',
+            '''@mcp.prompt()\ndef explain() -> str:\n    """Explain prompt."""\n    return "explain"\n''',
+            '''@mcp.tool()\ndef bravo() -> str:\n    """Bravo tool."""\n    return "bravo"\n''',
+        ]
+        if differing:
+            definitions.append(
+                '''@mcp.tool()\ndef charlie() -> str:\n    """Different tool."""\n    return "charlie"\n'''
+            )
+        if reverse:
+            definitions.reverse()
+        (directory / "catalog_actions.py").write_text(
+            "from actions import mcp\n\n" + "\n".join(definitions),
+            encoding="utf-8",
+        )
+
+    directories = [Path(tmpdir) / name for name in ("first", "second", "different")]
+    for directory in directories:
+        directory.mkdir()
+    write_catalog(directories[0], reverse=False, differing=False)
+    write_catalog(directories[1], reverse=True, differing=False)
+    write_catalog(directories[2], reverse=False, differing=True)
+
+    processes = [ActionServerProcess(directory) for directory in directories]
+    try:
+        for process, directory in zip(processes, directories):
+            process.start(
+                db_file="server.db",
+                cwd=directory,
+                actions_sync=True,
+                timeout=60 * 10,
+            )
+
+        async def catalog_for(process: ActionServerProcess) -> dict[str, object]:
+            base_url = f"http://localhost:{process.port}/mcp"
+            results = [
+                await _post_modern_mcp(base_url, method, request_id)
+                for request_id, method in enumerate(
+                    (
+                        "tools/list",
+                        "resources/list",
+                        "resources/templates/list",
+                        "prompts/list",
+                    ),
+                    start=1,
+                )
+            ]
+            revisions = {
+                result["_meta"]["actions.catalogRevision"] for result in results
+            }
+            assert len(revisions) == 1
+            return {
+                "revision": revisions.pop(),
+                "tools": [tool["name"] for tool in results[0]["tools"]],
+                "resources": [resource["uri"] for resource in results[1]["resources"]],
+                "templates": [
+                    template["uriTemplate"]
+                    for template in results[2]["resourceTemplates"]
+                ],
+                "prompts": [prompt["name"] for prompt in results[3]["prompts"]],
+            }
+
+        first, second, different = (
+            run_async_in_new_thread(lambda: catalog_for(processes[0])),
+            run_async_in_new_thread(lambda: catalog_for(processes[1])),
+            run_async_in_new_thread(lambda: catalog_for(processes[2])),
+        )
+        assert first == second
+        assert first["revision"] != different["revision"]
+        assert first["tools"] != different["tools"]
+    finally:
+        for process in reversed(processes):
+            process.stop()

--- a/action_server/tests/action_server_tests/mcp/test_setup_mcp_server.py
+++ b/action_server/tests/action_server_tests/mcp/test_setup_mcp_server.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_resource_template_matches():
     from actions.server.mcp.setup_mcp_server_from_actions import (
         McpServerSetupHelper,
@@ -357,3 +360,144 @@ def test_catalog_revision_changes_when_surface_changes_and_reload_clears_cache()
     helper.unregister_actions()
     assert helper.catalog_revision != before
     assert helper._tools == []
+
+
+def _catalog_action(
+    *,
+    action_id: str,
+    name: str,
+    options: dict,
+    docs: str,
+    input_schema: dict | None = None,
+):
+    import json
+
+    from actions.server._models import Action
+
+    return Action(
+        id=action_id,
+        action_package_id="package",
+        name=name,
+        docs=docs,
+        file="actions.py",
+        lineno=1,
+        input_schema=json.dumps(input_schema or {"type": "object", "properties": {}}),
+        output_schema=json.dumps({"type": "string"}),
+        enabled=True,
+        is_consequential=None,
+        managed_params_schema=None,
+        options=json.dumps(options),
+    )
+
+
+def _register_catalog_action(helper, action):
+    helper.register_action(
+        func=lambda **kwargs: "result",
+        action=action,
+        action_package=None,
+        display_name=action.name,
+        doc_desc=action.docs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("options", "names", "duplicate_key"),
+    [
+        ({"kind": "tool"}, ("duplicate", "duplicate"), "tool name"),
+        (
+            {"kind": "resource", "uri": "catalog://direct"},
+            ("first", "second"),
+            "resource URI",
+        ),
+        (
+            {"kind": "resource", "uri": "catalog://{item}"},
+            ("first", "second"),
+            "resource template URI",
+        ),
+        ({"kind": "prompt"}, ("duplicate", "duplicate"), "prompt name"),
+    ],
+)
+def test_duplicate_catalog_keys_are_rejected_in_opposite_registration_orders(
+    options, names, duplicate_key
+):
+    actions = [
+        _catalog_action(
+            action_id=f"{name}-{index}",
+            name=name,
+            options=options,
+            docs=f"definition {index}",
+        )
+        for index, name in enumerate(names)
+    ]
+
+    for registration_order in (actions, list(reversed(actions))):
+        from actions.server.mcp.setup_mcp_server_from_actions import (
+            McpServerSetupHelper,
+        )
+
+        helper = McpServerSetupHelper()
+        _register_catalog_action(helper, registration_order[0])
+        with pytest.raises(ValueError, match=f"duplicate {duplicate_key}"):
+            _register_catalog_action(helper, registration_order[1])
+
+
+def test_catalog_revision_changes_for_schema_and_meta_changes():
+    from actions.server.mcp.setup_mcp_server_from_actions import (
+        McpServerSetupHelper,
+    )
+
+    def revision_for(input_schema, mcp_meta):
+        helper = McpServerSetupHelper()
+        _register_catalog_action(
+            helper,
+            _catalog_action(
+                action_id="tool",
+                name="tool",
+                options={"kind": "tool", "_meta": mcp_meta},
+                docs="tool",
+                input_schema=input_schema,
+            ),
+        )
+        return helper.catalog_revision
+
+    base_schema = {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+    }
+    changed_schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+    }
+    base_meta = {"ui": {"resourceUri": "ui://base"}}
+    changed_meta = {"ui": {"resourceUri": "ui://changed"}}
+
+    base_revision = revision_for(base_schema, base_meta)
+    assert revision_for(changed_schema, base_meta) != base_revision
+    assert revision_for(base_schema, changed_meta) != base_revision
+
+
+def test_large_catalog_revision_is_bounded():
+    import time
+
+    from actions.server.mcp.setup_mcp_server_from_actions import (
+        McpServerSetupHelper,
+    )
+
+    helper = McpServerSetupHelper()
+    for index in range(1000):
+        _register_catalog_action(
+            helper,
+            _catalog_action(
+                action_id=f"tool-{index}",
+                name=f"tool_{index:04d}",
+                options={"kind": "tool"},
+                docs=f"tool {index}",
+            ),
+        )
+
+    started = time.perf_counter()
+    revision = helper.catalog_revision
+    elapsed = time.perf_counter() - started
+
+    assert len(revision) == 64
+    assert elapsed < 2.0, f"large catalog revision took {elapsed:.3f}s"

--- a/action_server/tests/action_server_tests/mcp/test_setup_mcp_server.py
+++ b/action_server/tests/action_server_tests/mcp/test_setup_mcp_server.py
@@ -273,3 +273,87 @@ def test_preserves_declared_mcp_meta_on_resources_and_prompts():
     assert direct_result.meta == declared_meta
     assert template_result.meta == declared_meta
     assert prompt_result.meta == declared_meta
+
+
+def test_catalogs_are_sorted_and_revisioned_independently_of_registration_order():
+    import asyncio
+    import json
+
+    from actions.server._models import Action
+    from actions.server.mcp.setup_mcp_server_from_actions import (
+        McpServerSetupHelper,
+    )
+
+    first = McpServerSetupHelper()
+    second = McpServerSetupHelper()
+    # The helper must derive the catalog from registered MCP definitions, not
+    # from the order in which the Action rows happened to be loaded.
+    for helper, names in (
+        (first, ["zulu", "alpha"]),
+        (second, ["alpha", "zulu"]),
+    ):
+        for name in names:
+            action = Action(
+                id=name,
+                action_package_id="package",
+                name=name,
+                docs=name,
+                file="actions.py",
+                lineno=1,
+                input_schema=json.dumps({"type": "object", "properties": {}}),
+                output_schema=json.dumps({"type": "string"}),
+                enabled=True,
+                is_consequential=None,
+                managed_params_schema=None,
+                options=json.dumps({"kind": "tool"}),
+            )
+            helper.register_action(
+                func=lambda **kwargs: "result",
+                action=action,
+                action_package=None,
+                display_name=name,
+                doc_desc=name,
+            )
+
+    assert [tool.name for tool in first._tools] == ["alpha", "zulu"]
+    assert [tool.name for tool in second._tools] == ["alpha", "zulu"]
+    assert first.catalog_revision == second.catalog_revision
+
+    result = asyncio.run(first._list_tools(None, None))
+    assert result.meta["actions.catalogRevision"] == first.catalog_revision
+
+
+def test_catalog_revision_changes_when_surface_changes_and_reload_clears_cache():
+    import json
+
+    from actions.server._models import Action
+    from actions.server.mcp.setup_mcp_server_from_actions import (
+        McpServerSetupHelper,
+    )
+
+    helper = McpServerSetupHelper()
+    action = Action(
+        id="one",
+        action_package_id="package",
+        name="one",
+        docs="one",
+        file="actions.py",
+        lineno=1,
+        input_schema=json.dumps({"type": "object", "properties": {}}),
+        output_schema=json.dumps({"type": "string"}),
+        enabled=True,
+        is_consequential=None,
+        managed_params_schema=None,
+        options=json.dumps({"kind": "tool"}),
+    )
+    helper.register_action(
+        func=lambda **kwargs: "result",
+        action=action,
+        action_package=None,
+        display_name="one",
+        doc_desc="one",
+    )
+    before = helper.catalog_revision
+    helper.unregister_actions()
+    assert helper.catalog_revision != before
+    assert helper._tools == []

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -70,11 +70,16 @@ The supported wire contract is MCP `2026-07-28`: discover, then make stateless
 per-request `/mcp` calls without `initialize`/`initialized` or
 `Mcp-Session-Id`; `/sse` is intentionally absent. SDK v2 catalog results carry
 `ttlMs: 0` and `cacheScope: private`, so they are immediately stale rather than
-indefinitely cacheable. Acceptance tests exercise independent replicas, a real
-forwarding gateway's `Mcp-Method`/`Mcp-Name` observation, header/cookie
-forwarding, catalog reload freshness, and Action option `_meta` propagation to
-the corresponding MCP definitions/results. Do not add Canvas behavior merely
-to maintain this adapter seam.
+indefinitely cacheable. Each tools/resources/resource-templates/prompts result
+also carries the same `actions.catalogRevision` SHA-256 fingerprint, computed
+from the canonical sorted MCP surface. Re-registering actions on reload
+therefore changes the revision when the surface changes, while independent
+Runtime processes with equivalent Actions produce the same revision. Acceptance
+tests exercise independent replicas, a real forwarding gateway's
+`Mcp-Method`/`Mcp-Name` observation, header/cookie forwarding, catalog reload
+freshness, deterministic ordering, and Action option `_meta` propagation to the
+corresponding MCP definitions/results. Do not add Canvas behavior merely to
+maintain this adapter seam.
 The accepted source and integration candidate use published clean-break
 distributions; lock regeneration is authoritative through Poetry 2.1.1 against
 PyPI, with clean-install verification kept as a separate release gate.

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -72,14 +72,18 @@ per-request `/mcp` calls without `initialize`/`initialized` or
 `ttlMs: 0` and `cacheScope: private`, so they are immediately stale rather than
 indefinitely cacheable. Each tools/resources/resource-templates/prompts result
 also carries the same `actions.catalogRevision` SHA-256 fingerprint, computed
-from the canonical sorted MCP surface. Re-registering actions on reload
-therefore changes the revision when the surface changes, while independent
-Runtime processes with equivalent Actions produce the same revision. Acceptance
-tests exercise independent replicas, a real forwarding gateway's
-`Mcp-Method`/`Mcp-Name` observation, header/cookie forwarding, catalog reload
-freshness, deterministic ordering, and Action option `_meta` propagation to the
-corresponding MCP definitions/results. Do not add Canvas behavior merely to
-maintain this adapter seam.
+from the canonical sorted MCP surface. Tool names, resource URIs, resource
+template URIs, and prompt names must be unique; duplicate keys are rejected at
+registration so each catalog's primary-key ordering is total without reordering
+semantic arrays inside schemas. Re-registering actions on reload therefore
+changes the revision when the surface changes. The independent-process
+acceptance starts separate Runtime processes with equivalent catalogs in
+opposite definition order and a third process with an extra tool, proving
+equal revisions for the equivalent pair and a different revision for the
+changed surface. Unit coverage also proves schema and `_meta` changes affect
+the revision. These tests do not establish the other distributed-runtime
+guarantees tracked by issue #82. Do not add Canvas behavior merely to maintain
+this adapter seam.
 The accepted source and integration candidate use published clean-break
 distributions; lock regeneration is authoritative through Poetry 2.1.1 against
 PyPI, with clean-install verification kept as a separate release gate.


### PR DESCRIPTION
## Summary

- Closes #89 with deterministic, revisioned MCP tool/resource/resource-template/prompt catalogs.
- Rejects duplicate catalog primary keys before mutation, making ordering total across replicas.
- Adds canonical SHA-256 `actions.catalogRevision` metadata and private `ttlMs: 0` cache hints.
- Proves reload invalidation and exact revision equality/difference across three independent Runtime processes.
- Documents the verified #89 contract without claiming broader #82 guarantees.

## Scope

Limited to MCP catalog construction, revision/cache metadata, tests, and canonical documentation. No authorization, interactive-flow, run ownership, database, artifact, frontend, release-workflow, or gateway-telemetry behavior changes.

## Verification

- RED duplicate-key regressions before repair: `4 failed, 9 passed`.
- Focused MCP: `25 passed`.
- Full MCP suite: `58 passed`.
- Independent three-process revision acceptance: passed.
- Schema and `_meta` revision changes, semantic array ordering, reload invalidation, and 1,000-tool bounded timing: passed.
- Ruff, type check, compileall, Poetry lock check, and `git diff --check`: passed.
- Hosted CI run `31903872288`: 5/5 checks passed.
- Independent Luna/max exact-SHA re-review: MERGE-READY at `acaf09833cb7b5e8f37b6f532efac088ebf2ac63`.

## Exact candidate

`acaf09833cb7b5e8f37b6f532efac088ebf2ac63`
