### PR TITLE
fix(recovery): execute immutable Runtime recovery

### DIFF
--- a/.github/workflows/_gen_workflows.py
+++ b/.github/workflows/_gen_workflows.py
@@ -1425,6 +1425,7 @@ test "$package_version" = "$tag_version"
     def recovery_admission_guard(self):
         return {
             "name": "Admit only merged community recovery code",
+            "working-directory": ".",
             "env": {
                 "WORKFLOW_REF": "${{ github.workflow_ref }}",
                 "WORKFLOW_SHA": "${{ github.workflow_sha }}",
@@ -1511,12 +1512,12 @@ jq -e --arg repo "$GITHUB_REPOSITORY" '
   [.artifacts[] | select(.workflow_run.id == 31755673247)] as $all
   | ($all | length == 4)
   and ($all | all(.expired == false))
-  and ($all | map({id,name,size_in_bytes,digest}) | sort_by(.name) == [
+  and ($all | map({id,name,size_in_bytes,digest}) | sort_by(.name) == ([
     {id:9202638277,name:"action-server-dist",size_in_bytes:848656,digest:"sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072"},
     {id:9202661215,name:"Linux-wheels",size_in_bytes:26180637,digest:"sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e"},
     {id:9202659672,name:"macOS-wheels",size_in_bytes:24523055,digest:"sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e"},
     {id:9202679653,name:"Windows-wheels",size_in_bytes:21134688,digest:"sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359"}
-  ])
+  ] | sort_by(.name)))
 ' <<<"$artifacts_json"
 """,
         }

--- a/.github/workflows/actions_runtime_recovery.yml
+++ b/.github/workflows/actions_runtime_recovery.yml
@@ -58,6 +58,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Admit only merged community recovery code
+      working-directory: .
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -149,6 +150,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Admit only merged community recovery code
+      working-directory: .
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -255,7 +257,7 @@ jobs:
         )\njq -e --arg repo \"$GITHUB_REPOSITORY\" '\n  [.artifacts[] | select(.workflow_run.id\
         \ == 31755673247)] as $all\n  | ($all | length == 4)\n  and ($all | all(.expired\
         \ == false))\n  and ($all | map({id,name,size_in_bytes,digest}) | sort_by(.name)\
-        \ == [\n    {id:9202638277,name:\"action-server-dist\",size_in_bytes:848656,digest:\"\
+        \ == ([\n    {id:9202638277,name:\"action-server-dist\",size_in_bytes:848656,digest:\"\
         sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072\"\
         },\n    {id:9202661215,name:\"Linux-wheels\",size_in_bytes:26180637,digest:\"\
         sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e\"\
@@ -263,7 +265,7 @@ jobs:
         sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e\"\
         },\n    {id:9202679653,name:\"Windows-wheels\",size_in_bytes:21134688,digest:\"\
         sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359\"\
-        }\n  ])\n' <<<\"$artifacts_json\"\n"
+        }\n  ] | sort_by(.name)))\n' <<<\"$artifacts_json\"\n"
     - name: Download retained action-server-dist
       env:
         ARTIFACT_ID: '9202638277'
@@ -441,6 +443,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Admit only merged community recovery code
+      working-directory: .
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -627,6 +630,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Admit only merged community recovery code
+      working-directory: .
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}

--- a/devutils/tests/test_runtime_release_workflows.py
+++ b/devutils/tests/test_runtime_release_workflows.py
@@ -975,6 +975,87 @@ def test_recovery_workflow_admits_only_merged_community_workflow_code():
     )
 
 
+def test_binary_recovery_admission_runs_from_workspace_root_before_release_checkout():
+    workflow = yaml.safe_load((WORKFLOWS / "actions_runtime_recovery.yml").read_text())
+    binary = workflow["jobs"]["binary-build"]
+    assert binary["defaults"]["run"]["working-directory"] == "release-source/action_server"
+    steps = binary["steps"]
+    admission_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Admit only merged community recovery code"
+    )
+    release_checkout_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Checkout immutable release source"
+    )
+    admission = steps[admission_index]
+    assert admission["working-directory"] == "."
+    assert admission_index < release_checkout_index
+
+
+def test_pypi_recovery_admission_canonicalizes_api_order_and_rejects_metadata_drift():
+    generator = (WORKFLOWS / "_gen_workflows.py").read_text()
+    recovery = (WORKFLOWS / "actions_runtime_recovery.yml").read_text()
+    expected = [
+        {
+            "id": 9202638277,
+            "name": "action-server-dist",
+            "size_in_bytes": 848656,
+            "digest": "sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072",
+        },
+        {
+            "id": 9202661215,
+            "name": "Linux-wheels",
+            "size_in_bytes": 26180637,
+            "digest": "sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e",
+        },
+        {
+            "id": 9202659672,
+            "name": "macOS-wheels",
+            "size_in_bytes": 24523055,
+            "digest": "sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e",
+        },
+        {
+            "id": 9202679653,
+            "name": "Windows-wheels",
+            "size_in_bytes": 21134688,
+            "digest": "sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359",
+        },
+    ]
+    api_order_fixture = list(reversed(expected))
+    jq_filter = "map({id,name,size_in_bytes,digest}) | sort_by(.name) == ($expected | sort_by(.name))"
+    assert "map({id,name,size_in_bytes,digest}) | sort_by(.name) == ([" in generator
+    assert generator.count("sort_by(.name)") >= 3
+    assert recovery.count("sort_by(.name)") >= 3
+    result = subprocess.run(
+        ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
+        input=json.dumps(api_order_fixture),
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    for field, value in (("name", "extra"), ("size_in_bytes", 1), ("digest", "sha256:wrong")):
+        invalid = list(expected)
+        invalid[0] = invalid[0] | {field: value}
+        result = subprocess.run(
+            ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
+            input=json.dumps(invalid),
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+    missing = expected[:-1]
+    result = subprocess.run(
+        ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
+        input=json.dumps(missing),
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+
+
 def test_recovery_reuses_pinned_artifact_ids_and_digests_without_clobber():
     generator = (WORKFLOWS / "_gen_workflows.py").read_text()
     recovery = (WORKFLOWS / "actions_runtime_recovery.yml").read_text()

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -186,6 +186,12 @@ otherwise unsafe. Every member is canonicalized and tracked before directory
 creation or file extraction, so duplicate directory records fail closed like
 duplicate regular files. API digest metadata alone is not artifact proof.
 
+The recovery workflow's binary matrix defaults to the immutable source directory,
+so its pre-checkout merged-community admission step explicitly runs from the
+workspace root. PyPI artifact admission sorts both the API collection and the
+canonical four-artifact expectation by name before comparing exact IDs, names,
+sizes, and digests; it still requires exactly four non-expired artifacts.
+
 The local verifier also accepts a successful canonical recovery dispatch, but only after
 binding the active recovery workflow's exact database ID/path, supported run metadata,
 manual-dispatch conclusion, immutable head SHA/community branch, exact


### PR DESCRIPTION
Fixes the two failures from authorized recovery run [31908040855](https://github.com/joshyorko/actions/actions/runs/31908040855).

- Run merged-community admission explicitly from the workspace root in the binary matrix before immutable source checkout.
- Compare canonical sorted PyPI artifact metadata on both sides while retaining exact four-only ID, name, size, digest, and expiry checks.
- Add regression coverage and update repository operations guidance.

Progresses #101

Verification:

- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pyyaml pytest devutils/tests/test_runtime_release_workflows.py -q` — 62 passed
- Generator twice with byte identity and no trailing blank
- YAML parse, 38 extracted Bash blocks with `bash -n`, Ruff, compile, `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/actions_runtime_recovery.yml`

No workflow was manually dispatched or re-dispatched. No tags/releases were mutated and no publication or PyPI upload side effect is included.
