### PR TITLE
fix: harden runtime recovery admission

### DIFF
--- a/.github/workflows/_gen_workflows.py
+++ b/.github/workflows/_gen_workflows.py
@@ -1525,13 +1525,27 @@ jq -e --argjson required '["build-sdist (ubuntu-py3.12)", "build-wheels (macos-1
 artifacts_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/artifacts?per_page=100" "${gh_api_headers[@]}")
 expected_artifacts='__EXPECTED_ARTIFACTS__'
 # shellcheck disable=SC2016
-jq_filter='[.artifacts[]? | select((.workflow_run?.id? | tostring) == $run) | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}] as $actual
-  | ($actual | length == 4)
-  and ($actual | all(.[]; (.id | type == "number" and . > 0) and (.name | type == "string" and length > 0) and (.size_in_bytes | type == "number" and . >= 0) and (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and (.expired == false) and (.workflow_run_id | tostring) == $run))
-  and ($expected | all(.[]; . as $wanted | ([$actual[] | select(.name == $wanted.name)] | length == 1 and .[0].id == $wanted.id and .[0].name == $wanted.name and .[0].size_in_bytes == $wanted.size_in_bytes and .[0].digest == $wanted.digest)))'
-if ! jq -e --arg run "$PYPI_SOURCE_RUN_ID" --argjson expected "$expected_artifacts" "$jq_filter" <<<"$artifacts_json"; then
-  echo "actual artifact metadata:" >&2
-  jq -c '[.artifacts[]? | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]' <<<"$artifacts_json" >&2 || true
+jq_filter='(.artifacts | type == "array" and length == 4) as $shape
+  | if ($shape | not) then false
+    else ([.artifacts[] | if type != "object" then false
+      else (has("id") and has("name") and has("size_in_bytes") and has("digest") and has("expired") and has("workflow_run")
+        and (.id | type == "number" and floor == . and . > 0)
+        and (.name | type == "string" and length > 0)
+        and (.size_in_bytes | type == "number" and floor == . and . >= 0)
+        and (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$"))
+        and (.expired == false)
+        and (if (.workflow_run | type) != "object" then false
+          else (.workflow_run | has("id"))
+            and (.workflow_run.id | type == "number" and floor == . and . == $run)
+          end)
+      ) end] | all) as $valid
+      | if ($valid | not) then false
+        else ([.artifacts[] | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}] as $actual
+          | ($expected | all(.[]; . as $wanted | ([$actual[] | select(.name == $wanted.name)] | length == 1 and .[0].id == $wanted.id and .[0].name == $wanted.name and .[0].size_in_bytes == $wanted.size_in_bytes and .[0].digest == $wanted.digest))))
+        end
+    end'
+if ! jq -e --argjson run "$PYPI_SOURCE_RUN_ID" --argjson expected "$expected_artifacts" "$jq_filter" <<<"$artifacts_json"; then
+  echo "artifact inventory validation failed; raw metadata withheld" >&2
   exit 1
 fi
 """.replace("__EXPECTED_ARTIFACTS__", expected_artifacts),

--- a/.github/workflows/_gen_workflows.py
+++ b/.github/workflows/_gen_workflows.py
@@ -15,6 +15,7 @@ Given that this will always regenerate the workflows, feel free to make
 refactorings in the structure as needed.
 """
 
+import json
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -1426,6 +1427,7 @@ test "$package_version" = "$tag_version"
         return {
             "name": "Admit only merged community recovery code",
             "working-directory": ".",
+            "shell": "bash",
             "env": {
                 "WORKFLOW_REF": "${{ github.workflow_ref }}",
                 "WORKFLOW_SHA": "${{ github.workflow_sha }}",
@@ -1468,6 +1470,18 @@ test "$(git -C recovery-code rev-parse refs/remotes/origin/community)" = "$WORKF
         }
 
     def pypi_source_validation(self):
+        expected_artifacts = json.dumps(
+            [
+                {
+                    "id": artifact_id,
+                    "name": name,
+                    "size_in_bytes": int(size),
+                    "digest": digest,
+                }
+                for name, (artifact_id, size, digest) in self.pypi_artifacts.items()
+            ],
+            separators=(",", ":"),
+        )
         return {
             "name": "Validate retained failed-run PyPI components",
             "env": {
@@ -1480,11 +1494,12 @@ test "$(git -C recovery-code rev-parse refs/remotes/origin/community)" = "$WORKF
             "run": """set -Eeuo pipefail
 test -n "$PYPI_SOURCE_RUN_ID"
 test -n "$PYPI_SOURCE_WORKFLOW_ID"
-workflow_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/actions_runtime_pypi_release.yml")
+gh_api_headers=(-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+workflow_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/actions_runtime_pypi_release.yml" "${gh_api_headers[@]}")
 test "$(jq -r '.id' <<<"$workflow_json")" = "$PYPI_SOURCE_WORKFLOW_ID"
 test "$(jq -r '.path' <<<"$workflow_json")" = ".github/workflows/actions_runtime_pypi_release.yml"
 test "$(jq -r '.state' <<<"$workflow_json")" = "active"
-run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID")
+run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID" "${gh_api_headers[@]}")
 jq -e --arg sha "$RELEASE_SHA" --arg ref "$RELEASE_REF" --arg workflow "$PYPI_SOURCE_WORKFLOW_ID" --arg run "$PYPI_SOURCE_RUN_ID" --arg repo "$GITHUB_REPOSITORY" '
   .id == ($run | tonumber)
   and .run_attempt == 1
@@ -1497,7 +1512,7 @@ jq -e --arg sha "$RELEASE_SHA" --arg ref "$RELEASE_REF" --arg workflow "$PYPI_SO
   and .repository.full_name == $repo
   and .head_repository.full_name == $repo
 ' <<<"$run_json"
-jobs_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/jobs?per_page=100")
+jobs_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/jobs?per_page=100" "${gh_api_headers[@]}")
 jq -e --argjson required '["build-sdist (ubuntu-py3.12)", "build-wheels (macos-15)", "build-wheels (ubuntu-22.04)", "build-wheels (windows-2022)"]' '
   [.jobs[] | select(.name as $name | ($required | index($name)) != null)] as $selected
   | ($selected | length == 4)
@@ -1507,19 +1522,19 @@ jq -e --argjson required '["build-sdist (ubuntu-py3.12)", "build-wheels (macos-1
   and ([.jobs[] | select(.name == "publish (3.12)")][0].conclusion == "failure")
   and ([.jobs[] | select(.name == "publish (3.12)")][0].steps[] | select(.name == "Verify merged tag provenance and version") | .conclusion) == ["failure"]
 ' <<<"$jobs_json"
-artifacts_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/artifacts?per_page=100")
-jq -e --arg repo "$GITHUB_REPOSITORY" '
-  [.artifacts[] | select(.workflow_run.id == 31755673247)] as $all
-  | ($all | length == 4)
-  and ($all | all(.expired == false))
-  and ($all | map({id,name,size_in_bytes,digest}) | sort_by(.name) == ([
-    {id:9202638277,name:"action-server-dist",size_in_bytes:848656,digest:"sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072"},
-    {id:9202661215,name:"Linux-wheels",size_in_bytes:26180637,digest:"sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e"},
-    {id:9202659672,name:"macOS-wheels",size_in_bytes:24523055,digest:"sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e"},
-    {id:9202679653,name:"Windows-wheels",size_in_bytes:21134688,digest:"sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359"}
-  ] | sort_by(.name)))
-' <<<"$artifacts_json"
-""",
+artifacts_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/artifacts?per_page=100" "${gh_api_headers[@]}")
+expected_artifacts='__EXPECTED_ARTIFACTS__'
+# shellcheck disable=SC2016
+jq_filter='[.artifacts[]? | select((.workflow_run?.id? | tostring) == $run) | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}] as $actual
+  | ($actual | length == 4)
+  and ($actual | all(.[]; (.id | type == "number" and . > 0) and (.name | type == "string" and length > 0) and (.size_in_bytes | type == "number" and . >= 0) and (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and (.expired == false) and (.workflow_run_id | tostring) == $run))
+  and ($expected | all(.[]; . as $wanted | ([$actual[] | select(.name == $wanted.name)] | length == 1 and .[0].id == $wanted.id and .[0].name == $wanted.name and .[0].size_in_bytes == $wanted.size_in_bytes and .[0].digest == $wanted.digest)))'
+if ! jq -e --arg run "$PYPI_SOURCE_RUN_ID" --argjson expected "$expected_artifacts" "$jq_filter" <<<"$artifacts_json"; then
+  echo "actual artifact metadata:" >&2
+  jq -c '[.artifacts[]? | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]' <<<"$artifacts_json" >&2 || true
+  exit 1
+fi
+""".replace("__EXPECTED_ARTIFACTS__", expected_artifacts),
         }
 
     def pypi_download_steps(self):

--- a/.github/workflows/actions_runtime_recovery.yml
+++ b/.github/workflows/actions_runtime_recovery.yml
@@ -266,20 +266,26 @@ jobs:
         digest\":\"sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e\"\
         },{\"id\":9202679653,\"name\":\"Windows-wheels\",\"size_in_bytes\":21134688,\"\
         digest\":\"sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359\"\
-        }]'\n# shellcheck disable=SC2016\njq_filter='[.artifacts[]? | select((.workflow_run?.id?\
-        \ | tostring) == $run) | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]\
-        \ as $actual\n  | ($actual | length == 4)\n  and ($actual | all(.[]; (.id\
-        \ | type == \"number\" and . > 0) and (.name | type == \"string\" and length\
-        \ > 0) and (.size_in_bytes | type == \"number\" and . >= 0) and (.digest |\
-        \ type == \"string\" and test(\"^sha256:[0-9a-f]{64}$\")) and (.expired ==\
-        \ false) and (.workflow_run_id | tostring) == $run))\n  and ($expected | all(.[];\
-        \ . as $wanted | ([$actual[] | select(.name == $wanted.name)] | length ==\
-        \ 1 and .[0].id == $wanted.id and .[0].name == $wanted.name and .[0].size_in_bytes\
-        \ == $wanted.size_in_bytes and .[0].digest == $wanted.digest)))'\nif ! jq\
-        \ -e --arg run \"$PYPI_SOURCE_RUN_ID\" --argjson expected \"$expected_artifacts\"\
-        \ \"$jq_filter\" <<<\"$artifacts_json\"; then\n  echo \"actual artifact metadata:\"\
-        \ >&2\n  jq -c '[.artifacts[]? | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]'\
-        \ <<<\"$artifacts_json\" >&2 || true\n  exit 1\nfi\n"
+        }]'\n# shellcheck disable=SC2016\njq_filter='(.artifacts | type == \"array\"\
+        \ and length == 4) as $shape\n  | if ($shape | not) then false\n    else ([.artifacts[]\
+        \ | if type != \"object\" then false\n      else (has(\"id\") and has(\"name\"\
+        ) and has(\"size_in_bytes\") and has(\"digest\") and has(\"expired\") and\
+        \ has(\"workflow_run\")\n        and (.id | type == \"number\" and floor ==\
+        \ . and . > 0)\n        and (.name | type == \"string\" and length > 0)\n\
+        \        and (.size_in_bytes | type == \"number\" and floor == . and . >=\
+        \ 0)\n        and (.digest | type == \"string\" and test(\"^sha256:[0-9a-f]{64}$\"\
+        ))\n        and (.expired == false)\n        and (if (.workflow_run | type)\
+        \ != \"object\" then false\n          else (.workflow_run | has(\"id\"))\n\
+        \            and (.workflow_run.id | type == \"number\" and floor == . and\
+        \ . == $run)\n          end)\n      ) end] | all) as $valid\n      | if ($valid\
+        \ | not) then false\n        else ([.artifacts[] | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]\
+        \ as $actual\n          | ($expected | all(.[]; . as $wanted | ([$actual[]\
+        \ | select(.name == $wanted.name)] | length == 1 and .[0].id == $wanted.id\
+        \ and .[0].name == $wanted.name and .[0].size_in_bytes == $wanted.size_in_bytes\
+        \ and .[0].digest == $wanted.digest))))\n        end\n    end'\nif ! jq -e\
+        \ --argjson run \"$PYPI_SOURCE_RUN_ID\" --argjson expected \"$expected_artifacts\"\
+        \ \"$jq_filter\" <<<\"$artifacts_json\"; then\n  echo \"artifact inventory\
+        \ validation failed; raw metadata withheld\" >&2\n  exit 1\nfi\n"
     - name: Download retained action-server-dist
       env:
         ARTIFACT_ID: '9202638277'

--- a/.github/workflows/actions_runtime_recovery.yml
+++ b/.github/workflows/actions_runtime_recovery.yml
@@ -59,6 +59,7 @@ jobs:
         persist-credentials: false
     - name: Admit only merged community recovery code
       working-directory: .
+      shell: bash
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -151,6 +152,7 @@ jobs:
         persist-credentials: false
     - name: Admit only merged community recovery code
       working-directory: .
+      shell: bash
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -230,42 +232,54 @@ jobs:
         RELEASE_SHA: ${{ inputs.release_sha }}
         GH_TOKEN: ${{ github.token }}
       run: "set -Eeuo pipefail\ntest -n \"$PYPI_SOURCE_RUN_ID\"\ntest -n \"$PYPI_SOURCE_WORKFLOW_ID\"\
-        \nworkflow_json=$(gh api \"repos/$GITHUB_REPOSITORY/actions/workflows/actions_runtime_pypi_release.yml\"\
-        )\ntest \"$(jq -r '.id' <<<\"$workflow_json\")\" = \"$PYPI_SOURCE_WORKFLOW_ID\"\
-        \ntest \"$(jq -r '.path' <<<\"$workflow_json\")\" = \".github/workflows/actions_runtime_pypi_release.yml\"\
-        \ntest \"$(jq -r '.state' <<<\"$workflow_json\")\" = \"active\"\nrun_json=$(gh\
-        \ api \"repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID\")\njq -e\
-        \ --arg sha \"$RELEASE_SHA\" --arg ref \"$RELEASE_REF\" --arg workflow \"\
-        $PYPI_SOURCE_WORKFLOW_ID\" --arg run \"$PYPI_SOURCE_RUN_ID\" --arg repo \"\
-        $GITHUB_REPOSITORY\" '\n  .id == ($run | tonumber)\n  and .run_attempt ==\
-        \ 1\n  and .workflow_id == ($workflow | tonumber)\n  and .path == \".github/workflows/actions_runtime_pypi_release.yml\"\
+        \ngh_api_headers=(-H \"Accept: application/vnd.github+json\" -H \"X-GitHub-Api-Version:\
+        \ 2022-11-28\")\nworkflow_json=$(gh api \"repos/$GITHUB_REPOSITORY/actions/workflows/actions_runtime_pypi_release.yml\"\
+        \ \"${gh_api_headers[@]}\")\ntest \"$(jq -r '.id' <<<\"$workflow_json\")\"\
+        \ = \"$PYPI_SOURCE_WORKFLOW_ID\"\ntest \"$(jq -r '.path' <<<\"$workflow_json\"\
+        )\" = \".github/workflows/actions_runtime_pypi_release.yml\"\ntest \"$(jq\
+        \ -r '.state' <<<\"$workflow_json\")\" = \"active\"\nrun_json=$(gh api \"\
+        repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID\" \"${gh_api_headers[@]}\"\
+        )\njq -e --arg sha \"$RELEASE_SHA\" --arg ref \"$RELEASE_REF\" --arg workflow\
+        \ \"$PYPI_SOURCE_WORKFLOW_ID\" --arg run \"$PYPI_SOURCE_RUN_ID\" --arg repo\
+        \ \"$GITHUB_REPOSITORY\" '\n  .id == ($run | tonumber)\n  and .run_attempt\
+        \ == 1\n  and .workflow_id == ($workflow | tonumber)\n  and .path == \".github/workflows/actions_runtime_pypi_release.yml\"\
         \n  and .head_sha == $sha\n  and .head_branch == $ref\n  and .event == \"\
         push\"\n  and .conclusion == \"failure\"\n  and .repository.full_name == $repo\n\
         \  and .head_repository.full_name == $repo\n' <<<\"$run_json\"\njobs_json=$(gh\
         \ api \"repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/jobs?per_page=100\"\
-        )\njq -e --argjson required '[\"build-sdist (ubuntu-py3.12)\", \"build-wheels\
-        \ (macos-15)\", \"build-wheels (ubuntu-22.04)\", \"build-wheels (windows-2022)\"\
-        ]' '\n  [.jobs[] | select(.name as $name | ($required | index($name)) != null)]\
-        \ as $selected\n  | ($selected | length == 4)\n  and (($selected | map(.name)\
-        \ | sort) == ($required | sort))\n  and ($selected | all(.[]; .status == \"\
-        completed\" and .conclusion == \"success\"))\n  and ([.jobs[] | select(.name\
-        \ == \"publish (3.12)\")] | length == 1)\n  and ([.jobs[] | select(.name ==\
-        \ \"publish (3.12)\")][0].conclusion == \"failure\")\n  and ([.jobs[] | select(.name\
-        \ == \"publish (3.12)\")][0].steps[] | select(.name == \"Verify merged tag\
-        \ provenance and version\") | .conclusion) == [\"failure\"]\n' <<<\"$jobs_json\"\
-        \nartifacts_json=$(gh api \"repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/artifacts?per_page=100\"\
-        )\njq -e --arg repo \"$GITHUB_REPOSITORY\" '\n  [.artifacts[] | select(.workflow_run.id\
-        \ == 31755673247)] as $all\n  | ($all | length == 4)\n  and ($all | all(.expired\
-        \ == false))\n  and ($all | map({id,name,size_in_bytes,digest}) | sort_by(.name)\
-        \ == ([\n    {id:9202638277,name:\"action-server-dist\",size_in_bytes:848656,digest:\"\
-        sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072\"\
-        },\n    {id:9202661215,name:\"Linux-wheels\",size_in_bytes:26180637,digest:\"\
-        sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e\"\
-        },\n    {id:9202659672,name:\"macOS-wheels\",size_in_bytes:24523055,digest:\"\
-        sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e\"\
-        },\n    {id:9202679653,name:\"Windows-wheels\",size_in_bytes:21134688,digest:\"\
-        sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359\"\
-        }\n  ] | sort_by(.name)))\n' <<<\"$artifacts_json\"\n"
+        \ \"${gh_api_headers[@]}\")\njq -e --argjson required '[\"build-sdist (ubuntu-py3.12)\"\
+        , \"build-wheels (macos-15)\", \"build-wheels (ubuntu-22.04)\", \"build-wheels\
+        \ (windows-2022)\"]' '\n  [.jobs[] | select(.name as $name | ($required |\
+        \ index($name)) != null)] as $selected\n  | ($selected | length == 4)\n  and\
+        \ (($selected | map(.name) | sort) == ($required | sort))\n  and ($selected\
+        \ | all(.[]; .status == \"completed\" and .conclusion == \"success\"))\n \
+        \ and ([.jobs[] | select(.name == \"publish (3.12)\")] | length == 1)\n  and\
+        \ ([.jobs[] | select(.name == \"publish (3.12)\")][0].conclusion == \"failure\"\
+        )\n  and ([.jobs[] | select(.name == \"publish (3.12)\")][0].steps[] | select(.name\
+        \ == \"Verify merged tag provenance and version\") | .conclusion) == [\"failure\"\
+        ]\n' <<<\"$jobs_json\"\nartifacts_json=$(gh api \"repos/$GITHUB_REPOSITORY/actions/runs/$PYPI_SOURCE_RUN_ID/artifacts?per_page=100\"\
+        \ \"${gh_api_headers[@]}\")\nexpected_artifacts='[{\"id\":9202638277,\"name\"\
+        :\"action-server-dist\",\"size_in_bytes\":848656,\"digest\":\"sha256:e68002161c7c05c7558339816733e56fc953fd8fe1bbf02f99f1f70c4a575072\"\
+        },{\"id\":9202661215,\"name\":\"Linux-wheels\",\"size_in_bytes\":26180637,\"\
+        digest\":\"sha256:e63ebadb20107adba8a6c76489105339337c1406db96ff328161dda9baf0c34e\"\
+        },{\"id\":9202659672,\"name\":\"macOS-wheels\",\"size_in_bytes\":24523055,\"\
+        digest\":\"sha256:5bba95082475ec10810edc3cf51a7a905ac135fd3fc58246be0f0244b53e281e\"\
+        },{\"id\":9202679653,\"name\":\"Windows-wheels\",\"size_in_bytes\":21134688,\"\
+        digest\":\"sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359\"\
+        }]'\n# shellcheck disable=SC2016\njq_filter='[.artifacts[]? | select((.workflow_run?.id?\
+        \ | tostring) == $run) | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]\
+        \ as $actual\n  | ($actual | length == 4)\n  and ($actual | all(.[]; (.id\
+        \ | type == \"number\" and . > 0) and (.name | type == \"string\" and length\
+        \ > 0) and (.size_in_bytes | type == \"number\" and . >= 0) and (.digest |\
+        \ type == \"string\" and test(\"^sha256:[0-9a-f]{64}$\")) and (.expired ==\
+        \ false) and (.workflow_run_id | tostring) == $run))\n  and ($expected | all(.[];\
+        \ . as $wanted | ([$actual[] | select(.name == $wanted.name)] | length ==\
+        \ 1 and .[0].id == $wanted.id and .[0].name == $wanted.name and .[0].size_in_bytes\
+        \ == $wanted.size_in_bytes and .[0].digest == $wanted.digest)))'\nif ! jq\
+        \ -e --arg run \"$PYPI_SOURCE_RUN_ID\" --argjson expected \"$expected_artifacts\"\
+        \ \"$jq_filter\" <<<\"$artifacts_json\"; then\n  echo \"actual artifact metadata:\"\
+        \ >&2\n  jq -c '[.artifacts[]? | {id,name,size_in_bytes,digest,expired,workflow_run_id:.workflow_run.id}]'\
+        \ <<<\"$artifacts_json\" >&2 || true\n  exit 1\nfi\n"
     - name: Download retained action-server-dist
       env:
         ARTIFACT_ID: '9202638277'
@@ -444,6 +458,7 @@ jobs:
         persist-credentials: false
     - name: Admit only merged community recovery code
       working-directory: .
+      shell: bash
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -631,6 +646,7 @@ jobs:
         persist-credentials: false
     - name: Admit only merged community recovery code
       working-directory: .
+      shell: bash
       env:
         WORKFLOW_REF: ${{ github.workflow_ref }}
         WORKFLOW_SHA: ${{ github.workflow_sha }}

--- a/devutils/tests/test_runtime_release_workflows.py
+++ b/devutils/tests/test_runtime_release_workflows.py
@@ -992,11 +992,11 @@ def test_binary_recovery_admission_runs_from_workspace_root_before_release_check
     )
     admission = steps[admission_index]
     assert admission["working-directory"] == "."
+    assert admission["shell"] == "bash"
     assert admission_index < release_checkout_index
 
 
-def test_pypi_recovery_admission_canonicalizes_api_order_and_rejects_metadata_drift():
-    generator = (WORKFLOWS / "_gen_workflows.py").read_text()
+def test_pypi_recovery_admission_is_auditable_and_fail_closed():
     recovery = (WORKFLOWS / "actions_runtime_recovery.yml").read_text()
     expected = [
         {
@@ -1024,36 +1024,45 @@ def test_pypi_recovery_admission_canonicalizes_api_order_and_rejects_metadata_dr
             "digest": "sha256:24daf1623d5b770b877b6e6d0b590b90b7b6d75f258b39cc1a20e30ca584f359",
         },
     ]
-    api_order_fixture = list(reversed(expected))
-    jq_filter = "map({id,name,size_in_bytes,digest}) | sort_by(.name) == ($expected | sort_by(.name))"
-    assert "map({id,name,size_in_bytes,digest}) | sort_by(.name) == ([" in generator
-    assert generator.count("sort_by(.name)") >= 3
-    assert recovery.count("sort_by(.name)") >= 3
-    result = subprocess.run(
-        ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
-        input=json.dumps(api_order_fixture),
-        text=True,
-        capture_output=True,
+    validation = next(
+        step["run"]
+        for step in yaml.safe_load(recovery)["jobs"]["pypi-recovery"]["steps"]
+        if step.get("name") == "Validate retained failed-run PyPI components"
     )
-    assert result.returncode == 0, result.stderr
-    for field, value in (("name", "extra"), ("size_in_bytes", 1), ("digest", "sha256:wrong")):
-        invalid = list(expected)
-        invalid[0] = invalid[0] | {field: value}
+    assert 'Accept: application/vnd.github+json' in validation
+    assert 'X-GitHub-Api-Version: 2022-11-28' in validation
+    assert "workflow_run_id" in validation
+    assert "actual artifact metadata" in validation
+    assert "sort_by(.name)" not in validation
+
+    def payload(items):
+        return {"artifacts": items}
+
+    base = [item | {"expired": False, "workflow_run": {"id": 31755673247}} for item in expected]
+    fixtures = [("reordered", list(reversed(base)), True)]
+    for label, replacement in (
+        ("extra", base + [base[0] | {"name": "unexpected"}]),
+        ("missing", base[:-1]),
+        ("duplicate", base[:-1] + [base[0]]),
+        ("wrong", base[:1] + [base[1] | {"digest": "sha256:wrong"}] + base[2:]),
+        ("omitted-id", base[:1] + [{key: value for key, value in base[1].items() if key != "id"}] + base[2:]),
+        ("null-name", base[:1] + [base[1] | {"name": None}] + base[2:]),
+        ("wrong-size", base[:1] + [base[1] | {"size_in_bytes": 1}] + base[2:]),
+        ("null-digest", base[:1] + [base[1] | {"digest": None}] + base[2:]),
+        ("expired", base[:1] + [base[1] | {"expired": True}] + base[2:]),
+        ("wrong-workflow", base[:1] + [base[1] | {"workflow_run": {"id": 9}}] + base[2:]),
+    ):
+        fixtures.append((label, replacement, False))
+
+    jq_filter = re.search(r"jq_filter='(.*?)'\nif ! jq", validation, re.DOTALL).group(1)
+    for label, items, should_pass in fixtures:
         result = subprocess.run(
-            ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
-            input=json.dumps(invalid),
+            ["jq", "-e", "--argjson", "expected", json.dumps(expected), "--arg", "run", "31755673247", jq_filter],
+            input=json.dumps(payload(items)),
             text=True,
             capture_output=True,
         )
-        assert result.returncode != 0
-    missing = expected[:-1]
-    result = subprocess.run(
-        ["jq", "-e", "--argjson", "expected", json.dumps(expected), jq_filter],
-        input=json.dumps(missing),
-        text=True,
-        capture_output=True,
-    )
-    assert result.returncode != 0
+        assert (result.returncode == 0) is should_pass, label
 
 
 def test_recovery_reuses_pinned_artifact_ids_and_digests_without_clobber():

--- a/devutils/tests/test_runtime_release_workflows.py
+++ b/devutils/tests/test_runtime_release_workflows.py
@@ -1032,7 +1032,8 @@ def test_pypi_recovery_admission_is_auditable_and_fail_closed():
     assert 'Accept: application/vnd.github+json' in validation
     assert 'X-GitHub-Api-Version: 2022-11-28' in validation
     assert "workflow_run_id" in validation
-    assert "actual artifact metadata" in validation
+    assert "raw metadata withheld" in validation
+    assert "jq -c '[.artifacts[]? | {id,name" not in validation
     assert "sort_by(.name)" not in validation
 
     def payload(items):
@@ -1042,7 +1043,9 @@ def test_pypi_recovery_admission_is_auditable_and_fail_closed():
     fixtures = [("reordered", list(reversed(base)), True)]
     for label, replacement in (
         ("extra", base + [base[0] | {"name": "unexpected"}]),
+        ("extra-wrong-run", base + [base[0] | {"name": "unexpected", "workflow_run": {"id": 9}}]),
         ("missing", base[:-1]),
+        ("missing-run", base[:1] + [{key: value for key, value in base[1].items() if key != "workflow_run"}] + base[2:]),
         ("duplicate", base[:-1] + [base[0]]),
         ("wrong", base[:1] + [base[1] | {"digest": "sha256:wrong"}] + base[2:]),
         ("omitted-id", base[:1] + [{key: value for key, value in base[1].items() if key != "id"}] + base[2:]),
@@ -1051,18 +1054,30 @@ def test_pypi_recovery_admission_is_auditable_and_fail_closed():
         ("null-digest", base[:1] + [base[1] | {"digest": None}] + base[2:]),
         ("expired", base[:1] + [base[1] | {"expired": True}] + base[2:]),
         ("wrong-workflow", base[:1] + [base[1] | {"workflow_run": {"id": 9}}] + base[2:]),
+        ("string-workflow-id", base[:1] + [base[1] | {"workflow_run": {"id": "31755673247"}}] + base[2:]),
+        ("null-workflow-id", base[:1] + [base[1] | {"workflow_run": {"id": None}}] + base[2:]),
+        ("object-workflow-id", base[:1] + [base[1] | {"workflow_run": {"id": {"value": 31755673247}}}] + base[2:]),
+        ("fractional-artifact-id", base[:1] + [base[1] | {"id": 9202661215.5}] + base[2:]),
+        ("fractional-size", base[:1] + [base[1] | {"size_in_bytes": 1.5}] + base[2:]),
+        ("malformed-artifact", base[:1] + [None] + base[2:]),
+        ("malformed-workflow-run", base[:1] + [base[1] | {"workflow_run": None}] + base[2:]),
+        ("url-shaped-name", base[:1] + [base[1] | {"name": "https://token.example/unsafe?secret=redacted"}] + base[2:]),
     ):
         fixtures.append((label, replacement, False))
 
     jq_filter = re.search(r"jq_filter='(.*?)'\nif ! jq", validation, re.DOTALL).group(1)
     for label, items, should_pass in fixtures:
         result = subprocess.run(
-            ["jq", "-e", "--argjson", "expected", json.dumps(expected), "--arg", "run", "31755673247", jq_filter],
+            ["jq", "-e", "--argjson", "expected", json.dumps(expected), "--argjson", "run", "31755673247", jq_filter],
             input=json.dumps(payload(items)),
             text=True,
             capture_output=True,
+            check=False,
         )
         assert (result.returncode == 0) is should_pass, label
+
+    unsafe_name = "https://token.example/unsafe?secret=redacted"
+    assert unsafe_name not in validation
 
 
 def test_recovery_reuses_pinned_artifact_ids_and_digests_without_clobber():

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -209,9 +209,9 @@ workspace root with `shell: bash` on every matrix OS. PyPI artifact admission
 uses GitHub's explicit JSON media type and `2022-11-28` API version headers, then
 fail-closed validates exactly four artifacts scoped to the source run. Each
 artifact must have one pinned ID, name, size, SHA-256 digest, `expired: false`,
-and the source workflow-run identity; API order is irrelevant. A mismatch emits
-only sanitized artifact ID/name/size/digest/expiry/workflow-run fields before
-any artifact download.
+and the source workflow-run identity; API order is irrelevant. The raw response
+must contain exactly four entries, and a mismatch emits only a fixed bounded
+failure message without artifact names, URLs, or payload metadata.
 
 The local verifier also accepts a successful canonical recovery dispatch, but only after
 binding the active recovery workflow's exact database ID/path, supported run metadata,

--- a/docs/skills/repository-operations.md
+++ b/docs/skills/repository-operations.md
@@ -205,9 +205,13 @@ duplicate regular files. API digest metadata alone is not artifact proof.
 
 The recovery workflow's binary matrix defaults to the immutable source directory,
 so its pre-checkout merged-community admission step explicitly runs from the
-workspace root. PyPI artifact admission sorts both the API collection and the
-canonical four-artifact expectation by name before comparing exact IDs, names,
-sizes, and digests; it still requires exactly four non-expired artifacts.
+workspace root with `shell: bash` on every matrix OS. PyPI artifact admission
+uses GitHub's explicit JSON media type and `2022-11-28` API version headers, then
+fail-closed validates exactly four artifacts scoped to the source run. Each
+artifact must have one pinned ID, name, size, SHA-256 digest, `expired: false`,
+and the source workflow-run identity; API order is irrelevant. A mismatch emits
+only sanitized artifact ID/name/size/digest/expiry/workflow-run fields before
+any artifact download.
 
 The local verifier also accepts a successful canonical recovery dispatch, but only after
 binding the active recovery workflow's exact database ID/path, supported run metadata,


### PR DESCRIPTION
## Summary

Progresses #101.

Repairs the two attributable defects from recovery run 31909946824:

- Binary recovery admission now explicitly uses Bash on every matrix OS, remains at `working-directory: .`, and stays before immutable-source checkout.
- PyPI recovery admission now sends explicit GitHub API headers and validates exactly four source-run artifacts fail-closed by pinned ID, name, size, SHA-256 digest, expiry, and workflow-run identity. API order is irrelevant; mismatches emit only sanitized artifact metadata before download.

## Root cause and evidence

- Windows inherited PowerShell while the admission script used Bash `[[ ... =~ ... ]]` syntax.
- The hosted PyPI gate used a monolithic shape-sensitive collection equality. The local fixture passed after canonical sorting, but the hosted payload/context exposed the fragile API-shape assumption. The replacement validates each field and identity independently, with explicit API version/media headers and sanitized diagnostics.
- Missing macOS signing variables (`MACOS_SIGNING_CERT`, `VAULT_URL`) remain an external blocker. Signing remains fail-closed; Linux unsigned success remains allowed.

## Verification

- `62 passed` — `devutils/tests/test_runtime_release_workflows.py`
- Ruff, compileall, YAML parse, `git diff --check`
- Focused actionlint on `.github/workflows/actions_runtime_recovery.yml`
- Generator regenerated twice with byte-identical recovery YAML

No recovery dispatch, signing/publish credentials, tag/release mutation, publish, or merge was performed.